### PR TITLE
implement PDF generation for visitor time log

### DIFF
--- a/src/app/admin/reports/reports.component.ts
+++ b/src/app/admin/reports/reports.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { PdfReportFacultyService } from '../../../services/pdf-report-faculty.service';
 import { PdfReportInventoryService } from '../../../services/pdf-report-inventory.service';
 import { PdfReportStudentsService } from '../../../services/pdf-report-students.service';
+import { PdfReportVisitorsService } from '../../../services/pdf-report-visitors.service';
 import { ExcelReportInventoryService } from '../../../services/excel-report-inventory.service';
 import { MaterialsService } from '../../../services/materials.service';
 
@@ -27,7 +28,8 @@ export class ReportsComponent implements OnInit {
     private pdfReportInventoryService: PdfReportInventoryService,
     private pdfReportStudentsService: PdfReportStudentsService,
     private excelInventoryReportService: ExcelReportInventoryService,
-    private materialService: MaterialsService
+    private materialService: MaterialsService,
+    private pdfReportVisitorsService: PdfReportVisitorsService,
   ) {}
 
   ngOnInit() {
@@ -93,7 +95,7 @@ export class ReportsComponent implements OnInit {
             this.generatePdfFacultyReport();
             break;      
       case 'Visitors':
-            console.log('Visitors');
+            this.generatePdfVisitorsReport()
             break;              
     }
   }
@@ -149,6 +151,16 @@ export class ReportsComponent implements OnInit {
   
   generatePdfStudentsReport() {
     this.pdfReportStudentsService.generatePDF(
+      'pdf-preview',
+      this.formatDate(this.dateFrom),
+      this.formatDate(this.dateTo),
+      (loading) => this.isLoading = loading,
+      (show) => this.showInitialDisplay = show
+    );
+  }
+
+  generatePdfVisitorsReport() {
+    this.pdfReportVisitorsService.generatePDF(
       'pdf-preview',
       this.formatDate(this.dateFrom),
       this.formatDate(this.dateTo),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -88,6 +88,7 @@ import { ReturnService } from '../services/return.service';
 import { PdfReportInventoryService } from '../services/pdf-report-inventory.service';
 import { PdfReportFacultyService } from '../services/pdf-report-faculty.service';
 import { PdfReportStudentsService } from '../services/pdf-report-students.service';
+import { PdfReportVisitorsService } from '../services/pdf-report-visitors.service';
 import { ExcelReportInventoryService } from '../services/excel-report-inventory.service';
 import { CurrentDateYearService } from '../services/current-date-year.service';
 
@@ -187,6 +188,7 @@ import { CurrentDateYearService } from '../services/current-date-year.service';
     ReturnService,
     PdfReportStudentsService,
     CurrentDateYearService,
+    PdfReportVisitorsService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/services/pdf-report-faculty.service.ts
+++ b/src/services/pdf-report-faculty.service.ts
@@ -75,7 +75,7 @@ export class PdfReportFacultyService {
 
         doc.setFontSize(10);
         //Date generated
-        doc.text(`REPORT GENERATED ON:`, labelXPosition, 
+        doc.text(`Report Generated On:`, labelXPosition, 
             doc.internal.pageSize.getHeight() - 20);
         doc.text(`${this.currentDateYearService
               .getCurrentYearAndDate('get_date')}`, valueXPosition, 
@@ -89,7 +89,7 @@ export class PdfReportFacultyService {
 
         //Filter
         if (dateFrom && dateTo) {
-          doc.text(`Time log ranging from:`, labelXPosition, 
+          doc.text(`Time Log Ranging From:`, labelXPosition, 
               doc.internal.pageSize.getHeight() - 10);
           doc.text(`${this.currentDateYearService
               .formatDateString(dateFrom)} - ${this.currentDateYearService

--- a/src/services/pdf-report-visitors.service.spec.ts
+++ b/src/services/pdf-report-visitors.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PdfReportVisitorsService } from './pdf-report-visitors.service';
+
+describe('PdfReportVisitorsService', () => {
+  let service: PdfReportVisitorsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PdfReportVisitorsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/services/pdf-report-visitors.service.ts
+++ b/src/services/pdf-report-visitors.service.ts
@@ -3,9 +3,8 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import { RecordsService } from './records.service';
 import { CurrentDateYearService } from './current-date-year.service';
-
 @Injectable()
-export class PdfReportStudentsService {
+export class PdfReportVisitorsService {
   constructor(private recordsService: RecordsService, 
               private currentDateYearService: CurrentDateYearService) {}
 
@@ -22,15 +21,14 @@ export class PdfReportStudentsService {
     const dateAndTime = `YEAR AS OF ${this.currentDateYearService
           .getCurrentYearAndDate('no_date')}`;
 
-    this.recordsService.getLogs('student', 10, 1, dateFrom, dateTo).subscribe(
+    this.recordsService.getLogs('visitor', 10, 1, dateFrom, dateTo).subscribe(
       response => {
-        const sudentData = response?.records || [];
-        const tableData = sudentData.map((student: any) => [
-          student.student_number,
-          student.name,
-          student.course,
-          student.time_in,
-          student.time_out ? student.time_out : 'await'
+        const facultyData = response?.records || [];
+        const tableData = facultyData.map((faculty: any) => [
+          faculty.school,
+          faculty.name,
+          faculty.time_in,
+          faculty.time_out ? faculty.time_out : 'await'
         ]);
 
         doc.setFontSize(16);
@@ -50,17 +48,17 @@ export class PdfReportStudentsService {
 
         let startY = 35;
         autoTable(doc, {
-          head: [['Student No.', 'Name', 'Department', 'Time In', 'Time Out']],
+          head: [['School', 'Name', 'Time In', 'Time Out']],
           body: tableData,
           startY: startY,
           theme: 'grid',
           headStyles: { fillColor: '#800000', textColor: [255, 255, 255] },
           columnStyles: {
-            0: { cellWidth: 40 },
-            1: { cellWidth: 70 },
-            2: { cellWidth: 40 },
+            0: { cellWidth: 75 },
+            1: { cellWidth: 75 },
+            2: { cellWidth: 60 },
             3: { cellWidth: 60 },
-            4: { cellWidth: 60 }
+           
           },
           styles: {
             overflow: 'linebreak',
@@ -76,18 +74,18 @@ export class PdfReportStudentsService {
 
         doc.setFontSize(10);
         //Date generated
-        doc.text(`Rport Generated On:`, labelXPosition, 
-          doc.internal.pageSize.getHeight() - 20);
-      doc.text(`${this.currentDateYearService
-            .getCurrentYearAndDate('get_date')}`, valueXPosition, 
-          doc.internal.pageSize.getHeight() - 20);
+        doc.text(`Report Generated On:`, labelXPosition, 
+            doc.internal.pageSize.getHeight() - 20);
+        doc.text(`${this.currentDateYearService
+              .getCurrentYearAndDate('get_date')}`, valueXPosition, 
+            doc.internal.pageSize.getHeight() - 20);
 
-      //Total records
-      doc.text(`Total Student Records:`, labelXPosition, 
-          doc.internal.pageSize.getHeight() - 15);
-      doc.text(`${sudentData.length}`, valueXPosition, 
-          doc.internal.pageSize.getHeight() - 15);
-          
+        //Total records
+        doc.text(`Total Faculty Records:`, labelXPosition, 
+            doc.internal.pageSize.getHeight() - 15);
+        doc.text(`${facultyData.length}`, valueXPosition, 
+            doc.internal.pageSize.getHeight() - 15);
+
         //Filter
         if (dateFrom && dateTo) {
           doc.text(`Time Log Ranging From:`, labelXPosition, 
@@ -97,6 +95,7 @@ export class PdfReportStudentsService {
               .formatDateString(dateTo)}`, valueXPosition, 
               doc.internal.pageSize.getHeight() - 10);
         }
+
         const pdfBlob = doc.output('blob');
         const pdfUrl = URL.createObjectURL(pdfBlob);
         const iframe = document.getElementById(iframeId) as HTMLIFrameElement;


### PR DESCRIPTION
`reports.component.ts`
- added generatePdfVisitorsReport method to handle visitor PDF report generation.

`pdf-report-visitors.service.ts`

- Logic for getting visitor time log data from backend and them formatting it into proper table format, then converting it to a PDF format.
- The same process for PDF generation with the Inventory, Student and Faculty. 
   - Connect to `records.service.ts` to be able to connect to backend API  `get_time_logs.php` to obtain time_log data for visitors 
   - Convert to PDF format
   - Shows pdf preview and then option to download
___

### Currently working for generating reports

PDF:
- [x] Inventory 
- [ ] Borrowers
- [x] Students
- [x] Faculty
- [x] Visitors

Excel:
- [x] Inventory 
- [ ] Borrowers
- [ ] Students
- [ ] Faculty
- [ ] Visitors