### PR TITLE
Implement monthly user page using line chart from chats.js library

### DIFF
--- a/controller_lis/fetch_monthly_users.php
+++ b/controller_lis/fetch_monthly_users.php
@@ -1,0 +1,102 @@
+<?php
+include 'db_connection.php';
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+$year = isset($_GET['year']) ? (int)$_GET['year'] : null;
+$wau = isset($_GET['wau']) ? $_GET['wau'] : 'monthly'; // Default to 'monthly'
+
+if ($year) {
+    if ($wau === 'daily') {
+        // Initialize an array to store the user count for each day of the month
+        $daily_counts = [];
+
+        // SQL query to count the number of users who timed in for each day of the given year
+        $sql = "SELECT 
+                    DATE(time_in) AS date, 
+                    COUNT(DISTINCT user_id) AS user_count
+                FROM time_log
+                WHERE YEAR(time_in) = ?
+                GROUP BY DATE(time_in)";
+
+        if ($stmt = $conn->prepare($sql)) {
+            // Bind the year parameter
+            $stmt->bind_param("i", $year);
+            $stmt->execute();
+            $result = $stmt->get_result();
+
+            while ($row = $result->fetch_assoc()) {
+                // Store the user count for each day
+                $daily_counts[$row['date']] = $row['user_count'];
+            }
+
+            $stmt->close();
+        } else {
+            echo json_encode(['error' => 'Failed to prepare the SQL statement.']);
+            exit;
+        }
+
+        echo json_encode($daily_counts);
+
+    } else {
+        // Initialize an array to store the user count for each month
+        $monthly_counts = [
+            'January' => 0,
+            'February' => 0,
+            'March' => 0,
+            'April' => 0,
+            'May' => 0,
+            'June' => 0,
+            'July' => 0,
+            'August' => 0,
+            'September' => 0,
+            'October' => 0,
+            'November' => 0,
+            'December' => 0,
+        ];
+
+        // SQL query to count the number of users who timed in for each month of the given year
+        $sql = "SELECT 
+                    MONTH(time_in) AS month, 
+                    COUNT(DISTINCT user_id) AS user_count
+                FROM time_log
+                WHERE YEAR(time_in) = ?
+                GROUP BY MONTH(time_in)";
+
+        if ($stmt = $conn->prepare($sql)) {
+            // Bind the year parameter
+            $stmt->bind_param("i", $year);
+            $stmt->execute();
+            $result = $stmt->get_result();
+
+            while ($row = $result->fetch_assoc()) {
+                // Map the month number to the month name and store the user count
+                $month_name = date("F", mktime(0, 0, 0, $row['month'], 10));
+                $monthly_counts[$month_name] = $row['user_count'];
+            }
+
+            $stmt->close();
+        } else {
+            echo json_encode(['error' => 'Failed to prepare the SQL statement.']);
+            exit;
+        }
+
+        echo json_encode($monthly_counts);
+    }
+} else {
+    echo json_encode(['error' => 'Year parameter is required.']);
+}
+
+$conn->close();
+?>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/platform-server": "^18.1.0",
         "@angular/router": "^18.1.0",
         "@angular/ssr": "^18.1.0",
+        "chart.js": "^4.4.4",
         "exceljs": "^4.4.0",
         "express": "^4.18.2",
         "file-saver": "^2.0.5",
@@ -3712,6 +3713,12 @@
         "tslib": "2"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -6082,6 +6089,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.4.tgz",
+      "integrity": "sha512-emICKGBABnxhMjUjlYRR12PmOXhJ2eJjEHL2/dZlWjxRAZT1D8xplLFq5M0tMQK8ja+wBS/tuVEJB5C6r7VxJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-server": "^18.1.0",
     "@angular/router": "^18.1.0",
     "@angular/ssr": "^18.1.0",
+    "chart.js": "^4.4.4",
     "exceljs": "^4.4.0",
     "express": "^4.18.2",
     "file-saver": "^2.0.5",

--- a/src/app/admin/analytics/monthly-users/monthly-users.component.css
+++ b/src/app/admin/analytics/monthly-users/monthly-users.component.css
@@ -1,0 +1,37 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.chart-container {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  position: relative;
+  height: 400px; /* Set a fixed height for the container */
+}
+
+/* Dropdown inside chart container */
+.dropdown-container {
+  position: absolute;
+  top: 10px; /* Adjust distance from the top */
+  right: 10px; /* Adjust distance from the right */
+  z-index: 10; /* Ensure dropdown is above other elements */
+}
+
+.dropdown {
+  background-color: #f8f8f8;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  padding: 5px;
+  font-size: 0.875rem; /* Smaller font size */
+  width: 120px; /* Adjust width as needed */
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.chart-container canvas {
+  width: 100% !important;
+  height: 100% !important; /* Ensure canvas takes full height of the container */
+}

--- a/src/app/admin/analytics/monthly-users/monthly-users.component.html
+++ b/src/app/admin/analytics/monthly-users/monthly-users.component.html
@@ -1,0 +1,13 @@
+<div class="container flex items-center justify-center min-h-screen">
+  <div class="w-full">
+    <div class="chart-container">
+      <div class="dropdown-container">
+        <label for="year" class="sr-only">Select Year:</label>
+        <select id="year" (change)="onYearChange($event)" class="dropdown">
+          <option *ngFor="let year of years" [value]="year">{{ year }}</option>
+        </select>
+      </div>
+      <canvas #lineChart></canvas>
+    </div>
+  </div>
+</div>

--- a/src/app/admin/analytics/monthly-users/monthly-users.component.spec.ts
+++ b/src/app/admin/analytics/monthly-users/monthly-users.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MonthlyUsersComponent } from './monthly-users.component';
+
+describe('MonthlyUsersComponent', () => {
+  let component: MonthlyUsersComponent;
+  let fixture: ComponentFixture<MonthlyUsersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MonthlyUsersComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MonthlyUsersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/analytics/monthly-users/monthly-users.component.ts
+++ b/src/app/admin/analytics/monthly-users/monthly-users.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 import { Chart, registerables } from 'chart.js';
-import { HttpClient } from '@angular/common/http';
+import { ChartsService } from '../../../../services/charts.service';
 
 Chart.register(...registerables);
 
@@ -15,7 +15,7 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
   public year: number = new Date().getFullYear();
   public years: number[] = [];
 
-  constructor(private http: HttpClient) {}
+  constructor(private chartsService: ChartsService) {}
 
   ngOnInit() {
     this.initializeYears();
@@ -31,7 +31,7 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
   }
 
   fetchData(year: number) {
-    this.http.get<any>(`http://localhost/controller_lis/fetch_monthly_users.php?year=${year}`)
+    this.chartsService.getMonthlyData(year)
       .subscribe(data => {
         console.log('Data received for chart:', data); // Log the data to check its format
         this.createChart(data, year);

--- a/src/app/admin/analytics/monthly-users/monthly-users.component.ts
+++ b/src/app/admin/analytics/monthly-users/monthly-users.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 import { Chart, registerables } from 'chart.js';
-import { ChartsService } from '../../../../services/charts.service';
+import { HttpClient } from '@angular/common/http';
 
 Chart.register(...registerables);
 
@@ -13,19 +13,16 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
   @ViewChild('lineChart', { static: false }) private chartRef!: ElementRef;
   public chart: any;
   public year: number = new Date().getFullYear();
-  public months: number[] = Array.from({ length: 12 }, (_, i) => i + 1);
-  public selectedMonth: number | null = null; // Track selected month for daily data
   public years: number[] = [];
-  public viewMode: 'monthly' | 'daily' = 'monthly'; // Track the selected view mode
 
-  constructor(private chartsService: ChartsService) {}
+  constructor(private http: HttpClient) {}
 
   ngOnInit() {
     this.initializeYears();
   }
 
   ngAfterViewInit() {
-    this.fetchData(this.year, this.viewMode, this.selectedMonth);
+    this.fetchData(this.year);
   }
 
   initializeYears() {
@@ -33,23 +30,17 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
     this.years = Array.from({ length: 100 }, (_, i) => currentYear - i);
   }
 
-  fetchData(year: number, viewMode: 'monthly' | 'daily', month?: number) {
-    let dataObservable;
-    if (viewMode === 'daily' && month) {
-      dataObservable = this.chartsService.getDailyData(year, month);
-    } else {
-      dataObservable = this.chartsService.getMonthlyData(year);
-    }
-
-    dataObservable.subscribe(data => {
-      console.log('Data received for chart:', data);
-      this.createChart(data, year, viewMode);
-    }, error => {
-      console.error('Error fetching data:', error);
-    });
+  fetchData(year: number) {
+    this.http.get<any>(`http://localhost/controller_lis/fetch_monthly_users.php?year=${year}`)
+      .subscribe(data => {
+        console.log('Data received for chart:', data); // Log the data to check its format
+        this.createChart(data, year);
+      }, error => {
+        console.error('Error fetching data:', error); // Log any errors
+      });
   }
 
-  createChart(data: any, selectedYear: number, viewMode: 'monthly' | 'daily') {
+  createChart(data: any, selectedYear: number) {
     const ctx = this.chartRef.nativeElement.getContext('2d');
     if (!ctx) {
       console.error('Failed to get canvas context');
@@ -60,35 +51,29 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
       this.chart.destroy();
     }
 
-    let labels: string[];
-    let values: number[];
+    const currentMonth = new Date().getMonth(); // Get the current month (0-based index)
+    const currentYear = new Date().getFullYear();
+    const allMonths = ['January', 'February', 'March', 
+                       'April', 'May', 'June', 
+                       'July', 'August', 'September', 
+                       'October', 'November', 'December'];
 
-    if (viewMode === 'daily') {
-      labels = Object.keys(data);
-      values = Object.values(data);
-    } else {
-      const allMonths = ['January', 'February', 'March', 
-                         'April', 'May', 'June', 
-                         'July', 'August', 'September', 
-                         'October', 'November', 'December'];
-      
-      const currentMonth = new Date().getMonth(); // Get the current month (0-based index)
-      labels = allMonths;
-      values = allMonths.map(month => data[month] || 0);
+    let displayedMonths = allMonths;
+    let displayedUsers = Object.values(data);
 
-      if (selectedYear === new Date().getFullYear()) {
-        labels = labels.slice(0, currentMonth + 1);
-        values = values.slice(0, currentMonth + 1);
-      }
+    if (selectedYear === currentYear) {
+      // If the selected year is the current year, show only up to the current month
+      displayedMonths = allMonths.slice(0, currentMonth + 1);
+      displayedUsers = displayedUsers.slice(0, currentMonth + 1);
     }
 
     this.chart = new Chart(ctx, {
       type: 'line',
       data: {
-        labels: labels,
+        labels: displayedMonths, // Use filtered month names as labels
         datasets: [{
           label: 'Number of Users',
-          data: values,
+          data: displayedUsers, // Filtered user counts for each month
           borderColor: '#FF5733',
           backgroundColor: 'rgba(255, 87, 51, 0.2)',
           borderWidth: 2,
@@ -118,22 +103,7 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
   }
 
   onYearChange(event: any) {
-    const selectedYear = +event.target.value;
-    this.year = selectedYear; // Update the current year
-    this.fetchData(selectedYear, this.viewMode, this.selectedMonth);
-  }
-
-  onViewModeChange(event: any) {
-    const selectedMode: 'monthly' | 'daily' = event.target.value;
-    this.viewMode = selectedMode;
-    this.fetchData(this.year, selectedMode, this.selectedMonth);
-  }
-
-  onMonthChange(event: any) {
-    const selectedMonth = +event.target.value;
-    this.selectedMonth = selectedMonth;
-    if (this.viewMode === 'daily') {
-      this.fetchData(this.year, 'daily', selectedMonth);
-    }
+    const selectedYear = +event.target.value; // Ensure selectedYear is treated as a number
+    this.fetchData(selectedYear);
   }
 }

--- a/src/app/admin/analytics/monthly-users/monthly-users.component.ts
+++ b/src/app/admin/analytics/monthly-users/monthly-users.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 import { Chart, registerables } from 'chart.js';
-import { HttpClient } from '@angular/common/http';
+import { ChartsService } from '../../../../services/charts.service';
 
 Chart.register(...registerables);
 
@@ -13,16 +13,19 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
   @ViewChild('lineChart', { static: false }) private chartRef!: ElementRef;
   public chart: any;
   public year: number = new Date().getFullYear();
+  public months: number[] = Array.from({ length: 12 }, (_, i) => i + 1);
+  public selectedMonth: number | null = null; // Track selected month for daily data
   public years: number[] = [];
+  public viewMode: 'monthly' | 'daily' = 'monthly'; // Track the selected view mode
 
-  constructor(private http: HttpClient) {}
+  constructor(private chartsService: ChartsService) {}
 
   ngOnInit() {
     this.initializeYears();
   }
 
   ngAfterViewInit() {
-    this.fetchData(this.year);
+    this.fetchData(this.year, this.viewMode, this.selectedMonth);
   }
 
   initializeYears() {
@@ -30,17 +33,23 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
     this.years = Array.from({ length: 100 }, (_, i) => currentYear - i);
   }
 
-  fetchData(year: number) {
-    this.http.get<any>(`http://localhost/controller_lis/fetch_monthly_users.php?year=${year}`)
-      .subscribe(data => {
-        console.log('Data received for chart:', data); // Log the data to check its format
-        this.createChart(data, year);
-      }, error => {
-        console.error('Error fetching data:', error); // Log any errors
-      });
+  fetchData(year: number, viewMode: 'monthly' | 'daily', month?: number) {
+    let dataObservable;
+    if (viewMode === 'daily' && month) {
+      dataObservable = this.chartsService.getDailyData(year, month);
+    } else {
+      dataObservable = this.chartsService.getMonthlyData(year);
+    }
+
+    dataObservable.subscribe(data => {
+      console.log('Data received for chart:', data);
+      this.createChart(data, year, viewMode);
+    }, error => {
+      console.error('Error fetching data:', error);
+    });
   }
 
-  createChart(data: any, selectedYear: number) {
+  createChart(data: any, selectedYear: number, viewMode: 'monthly' | 'daily') {
     const ctx = this.chartRef.nativeElement.getContext('2d');
     if (!ctx) {
       console.error('Failed to get canvas context');
@@ -51,29 +60,35 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
       this.chart.destroy();
     }
 
-    const currentMonth = new Date().getMonth(); // Get the current month (0-based index)
-    const currentYear = new Date().getFullYear();
-    const allMonths = ['January', 'February', 'March', 
-                       'April', 'May', 'June', 
-                       'July', 'August', 'September', 
-                       'October', 'November', 'December'];
+    let labels: string[];
+    let values: number[];
 
-    let displayedMonths = allMonths;
-    let displayedUsers = Object.values(data);
+    if (viewMode === 'daily') {
+      labels = Object.keys(data);
+      values = Object.values(data);
+    } else {
+      const allMonths = ['January', 'February', 'March', 
+                         'April', 'May', 'June', 
+                         'July', 'August', 'September', 
+                         'October', 'November', 'December'];
+      
+      const currentMonth = new Date().getMonth(); // Get the current month (0-based index)
+      labels = allMonths;
+      values = allMonths.map(month => data[month] || 0);
 
-    if (selectedYear === currentYear) {
-      // If the selected year is the current year, show only up to the current month
-      displayedMonths = allMonths.slice(0, currentMonth + 1);
-      displayedUsers = displayedUsers.slice(0, currentMonth + 1);
+      if (selectedYear === new Date().getFullYear()) {
+        labels = labels.slice(0, currentMonth + 1);
+        values = values.slice(0, currentMonth + 1);
+      }
     }
 
     this.chart = new Chart(ctx, {
       type: 'line',
       data: {
-        labels: displayedMonths, // Use filtered month names as labels
+        labels: labels,
         datasets: [{
           label: 'Number of Users',
-          data: displayedUsers, // Filtered user counts for each month
+          data: values,
           borderColor: '#FF5733',
           backgroundColor: 'rgba(255, 87, 51, 0.2)',
           borderWidth: 2,
@@ -103,7 +118,22 @@ export class MonthlyUsersComponent implements OnInit, AfterViewInit {
   }
 
   onYearChange(event: any) {
-    const selectedYear = +event.target.value; // Ensure selectedYear is treated as a number
-    this.fetchData(selectedYear);
+    const selectedYear = +event.target.value;
+    this.year = selectedYear; // Update the current year
+    this.fetchData(selectedYear, this.viewMode, this.selectedMonth);
+  }
+
+  onViewModeChange(event: any) {
+    const selectedMode: 'monthly' | 'daily' = event.target.value;
+    this.viewMode = selectedMode;
+    this.fetchData(this.year, selectedMode, this.selectedMonth);
+  }
+
+  onMonthChange(event: any) {
+    const selectedMonth = +event.target.value;
+    this.selectedMonth = selectedMonth;
+    if (this.viewMode === 'daily') {
+      this.fetchData(this.year, 'daily', selectedMonth);
+    }
   }
 }

--- a/src/app/admin/analytics/monthly-users/monthly-users.component.ts
+++ b/src/app/admin/analytics/monthly-users/monthly-users.component.ts
@@ -1,0 +1,109 @@
+import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+import { HttpClient } from '@angular/common/http';
+
+Chart.register(...registerables);
+
+@Component({
+  selector: 'app-monthly-users',
+  templateUrl: './monthly-users.component.html',
+  styleUrls: ['./monthly-users.component.css']
+})
+export class MonthlyUsersComponent implements OnInit, AfterViewInit {
+  @ViewChild('lineChart', { static: false }) private chartRef!: ElementRef;
+  public chart: any;
+  public year: number = new Date().getFullYear();
+  public years: number[] = [];
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.initializeYears();
+  }
+
+  ngAfterViewInit() {
+    this.fetchData(this.year);
+  }
+
+  initializeYears() {
+    const currentYear = new Date().getFullYear();
+    this.years = Array.from({ length: 100 }, (_, i) => currentYear - i);
+  }
+
+  fetchData(year: number) {
+    this.http.get<any>(`http://localhost/controller_lis/fetch_monthly_users.php?year=${year}`)
+      .subscribe(data => {
+        console.log('Data received for chart:', data); // Log the data to check its format
+        this.createChart(data, year);
+      }, error => {
+        console.error('Error fetching data:', error); // Log any errors
+      });
+  }
+
+  createChart(data: any, selectedYear: number) {
+    const ctx = this.chartRef.nativeElement.getContext('2d');
+    if (!ctx) {
+      console.error('Failed to get canvas context');
+      return;
+    }
+
+    if (this.chart) {
+      this.chart.destroy();
+    }
+
+    const currentMonth = new Date().getMonth(); // Get the current month (0-based index)
+    const currentYear = new Date().getFullYear();
+    const allMonths = ['January', 'February', 'March', 
+                       'April', 'May', 'June', 
+                       'July', 'August', 'September', 
+                       'October', 'November', 'December'];
+
+    let displayedMonths = allMonths;
+    let displayedUsers = Object.values(data);
+
+    if (selectedYear === currentYear) {
+      // If the selected year is the current year, show only up to the current month
+      displayedMonths = allMonths.slice(0, currentMonth + 1);
+      displayedUsers = displayedUsers.slice(0, currentMonth + 1);
+    }
+
+    this.chart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: displayedMonths, // Use filtered month names as labels
+        datasets: [{
+          label: 'Number of Users',
+          data: displayedUsers, // Filtered user counts for each month
+          borderColor: '#FF5733',
+          backgroundColor: 'rgba(255, 87, 51, 0.2)',
+          borderWidth: 2,
+          fill: true
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            beginAtZero: true,
+            grid: {
+              display: false
+            }
+          },
+          y: {
+            beginAtZero: true,
+            title: {
+              display: true,
+              text: 'Number of Users'
+            }
+          }
+        }
+      }
+    });
+  }
+
+  onYearChange(event: any) {
+    const selectedYear = +event.target.value; // Ensure selectedYear is treated as a number
+    this.fetchData(selectedYear);
+  }
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -66,6 +66,7 @@ import { EditDepartmentComponent } from './super-admin/edit-department/edit-depa
 import { AddSuccessfulComponent } from './super-admin/add-successful/add-successful.component';
 import { AddDepartmentSuccessComponent } from './super-admin/add-department-success/add-department-success.component';
 import { AnalyticsComponent } from './admin/analytics/analytics.component';
+import { MonthlyUsersComponent } from './admin/analytics/monthly-users/monthly-users.component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/landing', pathMatch: 'full' },
@@ -136,6 +137,7 @@ const routes: Routes = [
   { path: 'add-successful', component: AddSuccessfulComponent },
   { path: 'add-department-success', component: AddDepartmentSuccessComponent },
   { path: 'analytics', component: AnalyticsComponent },
+  {path: 'monthly-users', component: MonthlyUsersComponent},
 
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -106,6 +106,7 @@ import { AddDepartmentSuccessComponent } from './super-admin/add-department-succ
 import { AnalyticsComponent } from './admin/analytics/analytics.component';
 import { MostBorrowedComponent } from './admin/analytics/most-borrowed/most-borrowed.component';
 import { TopUsersComponent } from './admin/analytics/top-users/top-users.component';
+import { MonthlyUsersComponent } from './admin/analytics/monthly-users/monthly-users.component';
 
 
 @NgModule({
@@ -186,7 +187,8 @@ import { TopUsersComponent } from './admin/analytics/top-users/top-users.compone
     AddDepartmentSuccessComponent,
     AnalyticsComponent,
     MostBorrowedComponent,
-    TopUsersComponent
+    TopUsersComponent,
+    MonthlyUsersComponent
 
   ],
   imports: [

--- a/src/services/charts.service.spec.ts
+++ b/src/services/charts.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ChartsService } from './charts.service';
+
+describe('ChartsService', () => {
+  let service: ChartsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ChartsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/services/charts.service.ts
+++ b/src/services/charts.service.ts
@@ -1,20 +1,17 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from './environments/local-environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ChartsService {
-  private baseUrl = 'http://localhost/controller_lis';
+  private baseUrl = `${environment.apiUrl}/fetch_monthly_users.php`;
 
   constructor(private http: HttpClient) { }
 
   getMonthlyData(year: number): Observable<any> {
-    return this.http.get<any>(`${this.baseUrl}/fetch_monthly_users.php?year=${year}&wau=monthly`);
-  }
-
-  getDailyData(year: number, month: number): Observable<any> {
-    return this.http.get<any>(`${this.baseUrl}/fetch_monthly_users.php?year=${year}&month=${month}&wau=daily`);
+    return this.http.get<any>(`${this.baseUrl}?year=${year}&wau=monthly`);
   }
 }

--- a/src/services/charts.service.ts
+++ b/src/services/charts.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ChartsService {
+  private baseUrl = 'http://localhost/controller_lis';
+
+  constructor(private http: HttpClient) { }
+
+  getMonthlyData(year: number): Observable<any> {
+    return this.http.get<any>(`${this.baseUrl}/fetch_monthly_users.php?year=${year}&wau=monthly`);
+  }
+
+  getDailyData(year: number, month: number): Observable<any> {
+    return this.http.get<any>(`${this.baseUrl}/fetch_monthly_users.php?year=${year}&month=${month}&wau=daily`);
+  }
+}


### PR DESCRIPTION
>  Note: run "npm i" after git pull

`package-lock.json`
`package.json`

 - Add charts.js dependencies 

`monthly-users.component.html`
- Displays a line chart showing the number of users per month based on the selected year
- For now navigate via URL by adding 'monthly-users' in the URL

>  Sample:

 
![image](https://github.com/user-attachments/assets/006583ec-bc95-4668-9f45-69a11307ca64)
 
`monthly-users.component.ts`

- Logic handling the styling of the line chart using the charts.js library based on the response obtained from `fetch_monthly_users.php`
- Displays the number of users on the left side then the months on the bottom
- Initially displays the current year 
   - if current year is displayed, it will only display the months starting from January up until the current month
   - if past years were selected, display months Jan - Dec
-The dropdown allows the user to select which year to display 

`charts.service.ts`
- Connects to the backend API  `fetch_monthly_users.php` to receive the fetched data

`fetch_monthly_users.php`
- Fetches the number of users monthly based on the time_in column
- Expects the year to be added as header to be able to filter the obtained data by year
