### PR TITLE
update fetch_categories backend to order alphabetically by mat_type

### DIFF
--- a/controller_lis/fetch_categories.php
+++ b/controller_lis/fetch_categories.php
@@ -14,7 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS' ) {
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-$sql = "SELECT * FROM category";
+$sql = "SELECT * FROM category ORDER BY mat_type ASC"; // Order by cat_type in ascending order
 $result = $conn->query($sql);
 
 $categories = [];

--- a/controller_lis/fetch_categories.php
+++ b/controller_lis/fetch_categories.php
@@ -14,7 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS' ) {
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-$sql = "SELECT * FROM category ORDER BY mat_type ASC"; // Order by cat_type in ascending order
+$sql = "SELECT * FROM category ORDER BY mat_type ASC"; // Order by mat_type in ascending order
 $result = $conn->query($sql);
 
 $categories = [];


### PR DESCRIPTION
Dropdowns linked to the backend for category filter will now be displayed in alphabetical order to avoid confusion 