### PR TITLE
implement material type edit functionality

### DIFF
--- a/controller_lis/delete_category.php
+++ b/controller_lis/delete_category.php
@@ -1,0 +1,56 @@
+<?php
+include 'db_connection.php';
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// Get the input data from the request body
+$input = json_decode(file_get_contents('php://input'), true);
+$cat_id = isset($input['cat_id']) ? $input['cat_id'] : '';
+
+if (!$cat_id) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Category ID is required']);
+    exit;
+}
+
+// Check if there are any materials using this category
+$sql = "SELECT counter FROM category WHERE cat_id = ?";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("s", $cat_id);
+$stmt->execute();
+$stmt->bind_result($counter);
+$stmt->fetch();
+$stmt->close();
+
+if ($counter > 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Cannot delete category, there are materials using this category']);
+    exit;
+}
+
+// Delete the category
+$sql = "DELETE FROM category WHERE cat_id = ?";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("s", $cat_id);
+
+if ($stmt->execute()) {
+    echo json_encode(['success' => 'Category deleted successfully']);
+} else {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to delete category']);
+}
+
+$stmt->close();
+$conn->close();
+?>

--- a/controller_lis/edit_category.php
+++ b/controller_lis/edit_category.php
@@ -1,0 +1,47 @@
+<?php
+include 'db_connection.php';
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// Get the input data from the request body
+$input = json_decode(file_get_contents('php://input'), true);
+
+$cat_id = isset($input['cat_id']) ? $input['cat_id'] : '';
+$mat_type = isset($input['mat_type']) ? $input['mat_type'] : '';
+$cat_type = isset($input['cat_type']) ? $input['cat_type'] : '';
+$accession_no = isset($input['accession_no']) ? $input['accession_no'] : '';
+$duration = isset($input['duration']) ? $input['duration'] : null;
+
+// Check if all required fields are provided
+if (!$cat_id || !$mat_type || !$cat_type || !$accession_no) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Required fields are missing']);
+    exit;
+}
+
+// Update the category in the database
+$sql = "UPDATE category SET mat_type = ?, cat_type = ?, accession_no = ?, duration = ? WHERE cat_id = ?";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("sssss", $mat_type, $cat_type, $accession_no, $duration, $cat_id);
+
+if ($stmt->execute()) {
+    echo json_encode(['success' => 'Category updated successfully']);
+} else {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to update category']);
+}
+
+$stmt->close();
+$conn->close();
+?>

--- a/controller_lis/fetch_categories.php
+++ b/controller_lis/fetch_categories.php
@@ -6,7 +6,7 @@ header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
 header('Access-Control-Allow-Headers: Content-Type, Authorization');
 
-if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS' ) {
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
     http_response_code(200);
     exit;
 }
@@ -14,17 +14,36 @@ if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS' ) {
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-$sql = "SELECT * FROM category ORDER BY mat_type ASC"; // Order by mat_type in ascending order
-$result = $conn->query($sql);
+$cat_id = isset($_GET['cat_id']) ? $_GET['cat_id'] : '';
 
-$categories = [];
-if ($result->num_rows > 0) {
-    while ($row = $result->fetch_assoc()) {
-      $categories[] = $row;
+if ($cat_id) {
+    // Fetch a single row based on cat_id
+    $sql = "SELECT * FROM category WHERE cat_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("s", $cat_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $category = $result->fetch_assoc();
+
+    if ($category) {
+        echo json_encode($category);
+    } else {
+        echo json_encode(['error' => 'Category not found']);
     }
-}
+} else {
+    // Fetch all rows and order by mat_type ascending
+    $sql = "SELECT * FROM category ORDER BY mat_type ASC";
+    $result = $conn->query($sql);
 
-echo json_encode($categories);
+    $categories = [];
+    if ($result->num_rows > 0) {
+        while ($row = $result->fetch_assoc()) {
+            $categories[] = $row;
+        }
+    }
+
+    echo json_encode($categories);
+}
 
 $conn->close();
 ?>

--- a/src/app/admin/edit-type/edit-type.component.html
+++ b/src/app/admin/edit-type/edit-type.component.html
@@ -1,0 +1,156 @@
+<div class="flex items-end justify-center min-h-screen">
+  <div class="bg-white py-8 px-8 rounded-3xl shadow-lg w-3/4 h-full mb-52 slide-in-right">
+      <div class="flex items-center justify-between ml-5">
+          <h1 class="text-4xl text-primary font-medium ml-2 mb-4">Edit Material Type</h1>
+          <img src="../../../assets/book.png" alt="" class="w-36 h-24">
+      </div>
+      <div class="flex flex-row w-full">
+          <div class="flex flex-col w-1/3 items-center justify-center">
+              <div>
+                  <img src="../../../assets/read.svg" alt="" class="w-64 h-40">
+              </div>
+          </div>
+          <form (ngSubmit)="updateMaterialType()" class="w-3/4 items-center justify-center">
+              <div class="mb-4 mt-4 flex items-center space-x-4">
+                  <input
+                      id="classname"
+                      name="classname"
+                      [(ngModel)]="classname"
+                      type="text"
+                      class="flex-grow 
+                             w-full
+                             mt-1 
+                             block 
+                             rounded-full 
+                             border 
+                             border-gray-300 
+                             px-6 
+                             py-2 
+                             focus:ring-opacity-50 
+                             text-lg"
+                      placeholder="Classification name" />
+                  <div class="relative mr-44">
+                      <select
+                          id="type"
+                          name="type"
+                          [(ngModel)]="type"
+                          (ngModelChange)="onTypeChange($event)"
+                          class="block 
+                                 appearance-none 
+                                 w-full 
+                                 bg-secondary 
+                                 text-gray-700 
+                                 font-medium 
+                                 py-3 
+                                 px-6 
+                                 pr-8 
+                                 rounded-full 
+                                 leading-tight 
+                                 focus:outline-none 
+                                 focus:bg-[#ffb700] 
+                                 cursor-pointer 
+                                 text-lg">
+                          <option [ngValue]="true" disabled selected>Select Type</option>
+                          <option [ngValue]="false">Normal</option>
+                          <option [ngValue]="true">Special</option>
+                      </select>
+                      <div
+                          class="pointer-events-none 
+                                 absolute 
+                                 inset-y-0 
+                                 top-0.5 
+                                 right-3 
+                                 flex 
+                                 items-center 
+                                 text-gray-700">
+                          <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke-width="1.5"
+                              stroke="currentColor"
+                              class="size-5">
+                              <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                          </svg>
+                      </div>
+                  </div>
+              </div>
+              <div class="mb-4 flex items-center space-x-4">
+                  <input
+                      id="accnum"
+                      name="accnum"
+                      [(ngModel)]="accnum"
+                      type="text"
+                      class="flex-grow 
+                             w-full
+                             mt-1 
+                             block 
+                             rounded-full 
+                             border 
+                             border-gray-300 
+                             px-6 
+                             py-2 
+                             focus:ring-opacity-50 
+                             text-lg"
+                      placeholder="Accession number" />
+                  <input
+                      id="duration"
+                      name="duration"
+                      [(ngModel)]="duration"
+                      type="number"
+                      class="flex-grow 
+                             w-full
+                             mt-1 
+                             block 
+                             rounded-full 
+                             border 
+                             border-gray-300 
+                             px-6 
+                             py-2 
+                             focus:ring-opacity-50 
+                             text-lg"
+                      placeholder="Borrow Duration (Optional)" />
+              </div>
+              <div class="mb-4 flex items-center space-x-4">
+                  <button
+                      type="button"
+                      class="w-1/2 
+                             bg-primary 
+                             text-white 
+                             px-4 
+                             py-3 
+                             rounded-full 
+                             font-medium 
+                             hover:bg-[#ffb700] 
+                             hover:text-black 
+                             transition 
+                             duration-300 
+                             mt-0.5"
+                      routerLink="/materials-type">
+                      Back
+                  </button>
+                  <button
+                  type="submit"
+                  [disabled]="isSubmitting"
+                  class="w-1/2 
+                         bg-secondary 
+                         text-black 
+                         px-4 
+                         py-3 
+                         rounded-full 
+                         font-medium 
+                         hover:bg-[#801e1d] 
+                         hover:text-white 
+                         transition 
+                         duration-300 
+                         mt-0.5">
+                  Save Changes
+                </button>                
+              </div>
+          </form>
+      </div>
+  </div>
+</div>

--- a/src/app/admin/edit-type/edit-type.component.spec.ts
+++ b/src/app/admin/edit-type/edit-type.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditTypeComponent } from './edit-type.component';
+
+describe('EditTypeComponent', () => {
+  let component: EditTypeComponent;
+  let fixture: ComponentFixture<EditTypeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EditTypeComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EditTypeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/edit-type/edit-type.component.ts
+++ b/src/app/admin/edit-type/edit-type.component.ts
@@ -1,0 +1,79 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MaterialsService } from '../../../services/materials.service';
+
+@Component({
+  selector: 'app-edit-type',
+  templateUrl: './edit-type.component.html',
+  styleUrls: ['./edit-type.component.css']
+})
+export class EditTypeComponent implements OnInit {
+  classname: string;
+  type: boolean;
+  accnum: string;
+  duration: number;
+  isSubmitting = false;
+  cat_id: string; // To store the cat_id
+
+  constructor(
+    private materialService: MaterialsService, 
+    private router: Router,
+    private route: ActivatedRoute // Inject ActivatedRoute
+  ) {}
+
+  ngOnInit() {
+    // Extract cat_id from URL
+    this.cat_id = this.route.snapshot.paramMap.get('cat_id');
+    
+    // Fetch the data for this category ID
+    this.getCategoryDetails(this.cat_id);
+  }
+
+  getCategoryDetails(cat_id: string) {
+    this.materialService.getCategory(cat_id).subscribe(
+      (category) => {
+        // Bind the fetched data to the form fields
+        this.classname = category.mat_type;
+        this.type = category.cat_type === 'Special case';
+        this.accnum = category.accession_no;
+        this.duration = category.duration;
+      },
+      (error) => {
+        console.error('Error fetching category details', error);
+      }
+    );
+  }
+
+  onTypeChange(event: any) {
+    this.type = event;
+  }
+
+  updateMaterialType() {
+    if (this.isSubmitting) {
+      console.log('Submission already in progress');
+      return;
+    }
+
+    this.isSubmitting = true;
+    const categoryDetails = {
+      mat_type: this.classname,
+      cat_type: this.type ? 'Special case' : 'Normal',
+      accession_no: this.accnum,
+      duration: this.duration || null, // Set to null if not provided
+    };
+
+    console.log('Payload to be sent:', categoryDetails);
+
+    this.materialService.updateCategory(this.cat_id, categoryDetails).subscribe(
+      response => {
+        console.log('Category updated successfully', response);
+        this.isSubmitting = false;
+        this.router.navigate(['/materials-success']);
+      },
+      error => {
+        console.error('Error updating category', error);
+        this.isSubmitting = false;
+      }
+    );
+  }
+}

--- a/src/app/admin/materials-edit/materials-edit.component.html
+++ b/src/app/admin/materials-edit/materials-edit.component.html
@@ -33,30 +33,27 @@
               [(ngModel)]="material.category" />
             <div class="flex-1 relative">
               <div class="dropdown dropdown-end w-full">
-                <div tabindex="0" role="button"
-                     class="btn w-full bg-secondary 
-                            border-none text-black text-lg hover:bg-[#ffb700] 
-                            rounded-box flex items-center justify-between"
-                    (click)="toggleDropdown()">
-                  <span>{{ selectedCategory || 'Select Category' }}</span>
+                <div
+                  tabindex="0" role="button"
+                  class="btn w-full bg-secondary border-none text-black text-lg hover:bg-[#ffb700] rounded-box flex items-center justify-between"
+                  (click)="toggleDropdown()">
+                  <span>{{ selectedCategory?.mat_type || 'Select Category' }}</span>
                   <!-- Down Arrow Icon -->
-                  <svg xmlns="http://www.w3.org/2000/svg"
-                       class="w-4 h-4 ml-2" 
-                       fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" 
-                          stroke-width="2" d="M19 9l-7 7-7-7" />
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                   </svg>
                 </div>
                 <ul tabindex="0" *ngIf="isDropdownOpen"
-                    class="dropdown-content menu bg-secondary rounded-box z-[1] 
-                           w-full p-2 shadow text-lg font-medium text-black">
+                    class="dropdown-content menu bg-secondary rounded-box z-[1] w-full p-2 shadow text-lg font-medium text-black">
                   <li *ngFor="let category of categories">
-                    <a (click)="selectCategory(category)" 
-                       class="block px-4 py-2 hover:bg-[#ffb700] 
-                              hover:text-black">{{ category }}</a>
+                    <a (click)="selectCategory(category.cat_id, category.mat_type)" 
+                       class="block px-4 py-2 hover:bg-[#ffb700] hover:text-black">
+                      {{ category.mat_type }}
+                    </a>
                   </li>
                 </ul>
               </div>
+              
             </div>
           </div>
         </div>
@@ -234,40 +231,19 @@
     <h2 class="text-center text-xl font-medium text-primary mb-6">
       Do you really want to save these changes?
     </h2>
-    <div class="flex flex-col items-center justify-between h-full">
-      <img src="../../../assets/return.jpg" alt="success" class="w-4/5 h-auto mb-4" />
-      <div class="flex flex-row gap-4 w-full">
-        <button
-          (click)="closeConfirmModal()"
-          class="flex-1
-                 bg-primary 
-                 text-white 
-                 px-6 
-                 py-3 
-                 rounded-full 
-                 font-medium 
-                 hover:bg-[#ffb700] 
-                 hover:text-black 
-                 transition 
-                 duration-300">
-          Back
-        </button>
-        <button
-          (click)="saveChanges()"
-          class="flex-1
-                 bg-secondary 
-                 text-black 
-                 px-6 
-                 py-3 
-                 rounded-full 
-                 font-medium 
-                 hover:bg-[#801e1d] 
-                 hover:text-white 
-                 transition 
-                 duration-300">
-          Save changes
-        </button>
-      </div>
+    <div class="flex flex-col items-center">
+      <button
+        type="button"
+        class="w-full bg-primary text-white px-6 py-3 rounded-box font-medium hover:bg-secondary hover:text-black transition duration-300 mb-4"
+        (click)="saveChanges()">
+        Yes, Save changes
+      </button>
+      <button
+        type="button"
+        class="w-full bg-secondary text-black px-6 py-3 rounded-box font-medium hover:bg-[#ffb700] transition duration-300"
+        (click)="cancelChanges()">
+        No, Go back
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/admin/materials-type/materials-type.component.html
+++ b/src/app/admin/materials-type/materials-type.component.html
@@ -1,3 +1,4 @@
+<!-- Main Content -->
 <div class="flex items-center justify-center w-full min-h-screen">
   <div class="flex flex-row w-full">
     <div class="p-4 bg-white text-black rounded-3xl w-120 mb-12 slide-in-left ml-40">
@@ -43,7 +44,7 @@
         <form>
           <div class="flex flex-col items-center justify-between mt-5">
             <img src="../../../assets/hello.png" alt="success" class="w-96 h-72" />
-            <div class="flex flex-row gap-2 w-full">
+            <div class="flex flex-row gap-2 w-full mt-20">
               <button
                 type="button"
                 class="w-1/2 bg-primary text-white px-4 py-3 rounded-full font-medium hover:bg-[#ffb700] hover:text-black transition duration-300"
@@ -66,3 +67,63 @@
     </div>
   </div>
 </div>
+
+<!-- Confirmation Modal -->
+<div *ngIf="showModal" 
+     class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50">
+    <div class="bg-white p-8 rounded-3xl shadow-lg w-4/5 max-w-md">
+        <h2 class="text-center text-xl font-medium text-primary mb-3">
+            Do you really want to delete this material? It cannot be undone!
+            <div class="text-yellow-500 mt-4 mb-7">
+                <span class="text-primary">Title:</span> {{ selectedMaterialTitle }}
+            </div>
+        </h2>
+        <div class="flex flex-col items-center justify-between h-full">
+            <img src="../../../assets/return.jpg" alt="success" class="w-4/5 h-auto mb-4" />
+            <div class="flex flex-row gap-4 w-full">
+                <button
+                    (click)="closeConfirmModal()"
+                    class="flex-1
+                        bg-primary 
+                        text-white 
+                        px-6 
+                        py-3 
+                        rounded-full 
+                        font-medium 
+                        hover:bg-[#ffb700] 
+                        hover:text-black 
+                        transition 
+                        duration-300">
+                    Back
+                </button>
+                <button
+                    (click)="deleteCategory()"
+                    class="flex-1
+                        bg-secondary 
+                        text-black 
+                        px-6 
+                        py-3 
+                        rounded-full 
+                        font-medium 
+                        hover:bg-[#801e1d] 
+                        hover:text-white 
+                        transition 
+                        duration-300">
+                    Confirm Delete
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Snackbar -->
+<div *ngIf="snackBarVisible" 
+     class="fixed bottom-0 left-1/2 transform -translate-x-1/2 
+            mb-4 bg-yellow-500 text-white p-4 
+            rounded-lg shadow-lg flex items-center">
+    <span>{{ snackBarMessage }}</span>
+    <button (click)="closeSnackBar()" class="ml-4 text-white">
+        <span class="text-xl font-bold">×</span>
+    </button>
+</div>
+

--- a/src/app/admin/materials-type/materials-type.component.html
+++ b/src/app/admin/materials-type/materials-type.component.html
@@ -1,59 +1,68 @@
 <div class="flex items-center justify-center w-full min-h-screen">
-    <div class="flex flex-row w-full">
-      <div class="p-4 bg-white text-black rounded-3xl w-96 mb-12 slide-in-left ml-40">
-        <div class="overflow-x-auto">
-          <table class="table w-full">
-            <thead>
-              <tr class="text-primary text-center">
-                <th>Material Types</th>
-                <th>Accession No. Template</th>
-              </tr>
-            </thead>
-            <tbody class="text-center">
-              <tr *ngFor="let category of categories">
-                <td>{{ category.mat_type }}</td>
-                <td>{{ category.accession_no }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+  <div class="flex flex-row w-full">
+    <div class="p-4 bg-white text-black rounded-3xl w-120 mb-12 slide-in-left ml-40">
+      <div class="overflow-x-auto">
+        <table class="table w-full">
+          <thead>
+            <tr class="text-primary text-center">
+              <th>Material Types</th>
+              <th>Accession No. Template</th>
+              <th>Edit</th>
+              <th>Delete</th>
+            </tr>
+          </thead>
+          <tbody class="text-center">
+            <tr *ngFor="let category of categories">
+              <td>{{ category.mat_type }}</td>
+              <td>{{ category.accession_no }}</td>
+              <td>
+                <button
+                  class="bg-secondary text-black border-none shadow-none btn-sm rounded-full font-medium mr-1"
+                  (click)="editCategory(category.cat_id)">
+                  Edit
+                </button>
+              </td>
+              <td>
+                <button
+                  class="bg-primary text-white border-none shadow-none btn-sm rounded-full font-medium"
+                  (click)="showConfirmModal(category.cat_id, category.mat_type)">
+                  Delete
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-      <div class="flex flex-col w-full">
-        <div class="bg-white p-8 pb-0 rounded-3xl 
-                    shadow-lg ml-20 w-1/2 h-3/5 slide-in-right">
-          <span class="text-center text-2xl font-normal text-black mb-3">
-            Total library materials count:
-          </span>
-          <span class="text-primary text-2xl font-medium">{{ totalCount }}</span>
-          <form>
-            <div class="flex flex-col items-center justify-between mt-5">
-              <img src="../../../assets/hello.png" alt="success" class="w-96 h-72" />
-              <div class="flex flex-row gap-2 w-full">
-                <button
-                  type="button"
-                  class="w-1/2 bg-primary text-white px-4 py-3 
-                         rounded-full font-medium hover:bg-[#ffb700] 
-                         hover:text-black transition duration-300"
-                  (click)="goBack()">
-                  Back
-                </button>
-                <button
-                  type="button"
-                  class="w-1/2 bg-secondary text-black px-4 py-3 
-                         rounded-full font-medium hover:bg-[#801e1d] 
-                         hover:text-white transition duration-300"
-                  routerLink="/add-type">
-                  Add material type
-                </button>
-              </div>
+    </div>
+    <div class="flex flex-col w-full">
+      <div class="bg-white p-8 pb-0 rounded-3xl shadow-lg ml-20 w-1/2 h-3/5 slide-in-right">
+        <span class="text-center text-2xl font-normal text-black mb-3">
+          Total library materials count:
+        </span>
+        <span class="text-primary text-2xl font-medium">{{ totalCount }}</span>
+        <form>
+          <div class="flex flex-col items-center justify-between mt-5">
+            <img src="../../../assets/hello.png" alt="success" class="w-96 h-72" />
+            <div class="flex flex-row gap-2 w-full">
+              <button
+                type="button"
+                class="w-1/2 bg-primary text-white px-4 py-3 rounded-full font-medium hover:bg-[#ffb700] hover:text-black transition duration-300"
+                (click)="goBack()">
+                Back
+              </button>
+              <button
+                type="button"
+                class="w-1/2 bg-secondary text-black px-4 py-3 rounded-full font-medium hover:bg-[#801e1d] hover:text-white transition duration-300"
+                routerLink="/add-type">
+                Add material type
+              </button>
             </div>
-          </form>
-        </div>
-        <div class="flex items-center justify-center 
-                    ml-10 mt-5 w-3/5 h-1/3 slide-in-below">
-          <img src="../../../assets/books.png" alt="books" class="w-96 h-72">
-        </div>
+          </div>
+        </form>
+      </div>
+      <div class="flex items-center justify-center ml-10 mt-5 w-3/5 h-1/3 slide-in-below">
+        <img src="../../../assets/books.png" alt="books" class="w-96 h-72">
       </div>
     </div>
   </div>
-  
+</div>

--- a/src/app/admin/materials-type/materials-type.component.ts
+++ b/src/app/admin/materials-type/materials-type.component.ts
@@ -11,6 +11,11 @@ import { Router } from '@angular/router';
 export class MaterialsTypeComponent implements OnInit {
   categories: any[] = [];
   totalCount: number = 0;
+  snackBarVisible: boolean = false;
+  snackBarMessage: string = '';
+  showModal: boolean = false;
+  selectedCategoryId: string = '';
+  selectedMaterialTitle: string = '';
 
   constructor(private location: Location, private materialsService: MaterialsService, private router: Router) {}
 
@@ -44,12 +49,40 @@ export class MaterialsTypeComponent implements OnInit {
   editCategory(cat_id: string): void {
     this.router.navigate(['/edit-type', cat_id]);
   }
-  //TODO implement delete material type
+
   showConfirmModal(cat_id: string, mat_type: string): void {
+    this.selectedCategoryId = cat_id;
+    this.selectedMaterialTitle = mat_type;
+    this.showModal = true;
+  }
 
-    if (confirm(`Are you sure you want to delete the material type: ${mat_type}?`)) {
+  closeConfirmModal(): void {
+    this.showModal = false;
+  }
 
-      console.log('Delete category with cat_id:', cat_id);
-    }
+  deleteCategory(): void {
+    this.materialsService.deleteCategory(this.selectedCategoryId).subscribe(
+      response => {
+        if (response.error) {
+          this.snackBarMessage = response.error;
+          this.snackBarVisible = true;
+        } else {
+          this.snackBarMessage = response.success;
+          this.snackBarVisible = true;
+          this.getCategories(); // Refresh the categories list
+        }
+        this.closeConfirmModal();
+      },
+      error => {
+        console.error('Error deleting category', error);
+        this.snackBarMessage = 'Cannot delete, there are materials using this category';
+        this.snackBarVisible = true;
+        this.closeConfirmModal();
+      }
+    );
+  }
+
+  closeSnackBar(): void {
+    this.snackBarVisible = false;
   }
 }

--- a/src/app/admin/materials-type/materials-type.component.ts
+++ b/src/app/admin/materials-type/materials-type.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { MaterialsService } from '../../../services/materials.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-materials-type',
@@ -11,7 +12,7 @@ export class MaterialsTypeComponent implements OnInit {
   categories: any[] = [];
   totalCount: number = 0;
 
-  constructor(private location: Location, private materialsService: MaterialsService) {}
+  constructor(private location: Location, private materialsService: MaterialsService, private router: Router) {}
 
   ngOnInit(): void {
     this.getCategories();
@@ -31,7 +32,6 @@ export class MaterialsTypeComponent implements OnInit {
 
   calculateTotalCount(): void {
     this.totalCount = this.categories.reduce((total, category) => {
-      // Ensure the counter value is a number
       const counterValue = parseInt(category.counter || '0', 10);
       return total + counterValue;
     }, 0);
@@ -39,5 +39,17 @@ export class MaterialsTypeComponent implements OnInit {
 
   goBack(): void {
     this.location.back();
+  }
+
+  editCategory(cat_id: string): void {
+    this.router.navigate(['/edit-type', cat_id]);
+  }
+  //TODO implement delete material type
+  showConfirmModal(cat_id: string, mat_type: string): void {
+
+    if (confirm(`Are you sure you want to delete the material type: ${mat_type}?`)) {
+
+      console.log('Delete category with cat_id:', cat_id);
+    }
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -69,6 +69,7 @@ import { AnalyticsComponent } from './admin/analytics/analytics.component';
 import { MonthlyUsersComponent } from './admin/analytics/monthly-users/monthly-users.component';
 import { MonthlyCategoryDonutComponent } from './admin/analytics/monthly-category-donut/monthly-category-donut.component';
 import { TopTenUserTimeinComponent } from './admin/analytics/top-ten-user-timein/top-ten-user-timein.component';
+import { EditTypeComponent } from './admin/edit-type/edit-type.component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/landing', pathMatch: 'full' },
@@ -139,9 +140,11 @@ const routes: Routes = [
   { path: 'add-successful', component: AddSuccessfulComponent },
   { path: 'add-department-success', component: AddDepartmentSuccessComponent },
   { path: 'analytics', component: AnalyticsComponent },
-  {path: 'monthly-users', component: MonthlyUsersComponent},
-  {path: 'category-donut',component: MonthlyCategoryDonutComponent},
-  {path: 'top-users', component: TopTenUserTimeinComponent,}
+  { path: 'monthly-users', component: MonthlyUsersComponent},
+  { path: 'category-donut',component: MonthlyCategoryDonutComponent},
+  { path: 'top-users', component: TopTenUserTimeinComponent},
+  { path: 'edit-type/:cat_id', component: EditTypeComponent },
+
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -114,6 +114,7 @@ import { TopUsersComponent } from './admin/analytics/top-users/top-users.compone
 import { MonthlyUsersComponent } from './admin/analytics/monthly-users/monthly-users.component';
 import { MonthlyCategoryDonutComponent } from './admin/analytics/monthly-category-donut/monthly-category-donut.component';
 import { TopTenUserTimeinComponent } from './admin/analytics/top-ten-user-timein/top-ten-user-timein.component';
+import { EditTypeComponent } from './admin/edit-type/edit-type.component';
 
 
 
@@ -199,6 +200,7 @@ import { TopTenUserTimeinComponent } from './admin/analytics/top-ten-user-timein
     MonthlyUsersComponent,
     MonthlyCategoryDonutComponent,
     TopTenUserTimeinComponent,
+    EditTypeComponent,
 
   ],
   imports: [

--- a/src/services/materials.service.ts
+++ b/src/services/materials.service.ts
@@ -88,4 +88,8 @@ export class MaterialsService {
   updateCategory(cat_id: string, categoryDetails: any): Observable<any> {
     return this.http.post<any>(`${this.apiUrl}/edit_category.php`, { cat_id, ...categoryDetails });
   }
+
+    deleteCategory(cat_id: string): Observable<any> {
+    return this.http.post<any>(`${this.apiUrl}/delete_category.php`, { cat_id });
+  }
 }

--- a/src/services/materials.service.ts
+++ b/src/services/materials.service.ts
@@ -80,4 +80,12 @@ export class MaterialsService {
   getCategories(): Observable<any> {
     return this.http.get<any>(`${this.apiUrl}/fetch_categories.php`);
   }
+
+  getCategory(cat_id: string): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}/fetch_categories.php?cat_id=${cat_id}`);
+  }
+
+  updateCategory(cat_id: string, categoryDetails: any): Observable<any> {
+    return this.http.post<any>(`${this.apiUrl}/edit_category.php`, { cat_id, ...categoryDetails });
+  }
 }


### PR DESCRIPTION
### implement material type edit functionality
`material-type component`

- updated with edit buttons
   - clicking the edit buttons will navigate to the edit-type component and will pass the cat_id in the URL. The cat_id depends on which cateogy was selected to be edited.
  
![image](https://github.com/user-attachments/assets/8ee1934e-819b-42a1-bf6c-3a1369911b19)

`edit_category.php`
- Backend logic for editing a material type / category
- Takes a request that includes the cat_id to determine which specific category to edit or update

`fetch_categories.php`
- Updated to include logic for getting only a singular row from the category table
   - if cat_id is passed on the backend call it fetches only the details of that specific row 
   - if not fetch all details

`edit-type.component.html`
- Display editable details for the material type / category
- Display the current values in its respective input fields
- If save changes button is clicked pass the edited values to the backend API: `edit_category.php`


`edit-type.component.ts`
- Uses the cat_id received from the material-tpye component to determine which category to display in the input fields


___

### Implement Delete Material Type Functionality

`delete_category.php`

- Backend logic for deleteing a category / material type
   - Pass in a cat_id for the identifier for which row to delete
   - If  the counter column is  greater than 0 do not delete the category and show that message to the user to avoid deleting category that is being used in the materials table

`material-type.componenet.hmtl`
- Added modal for delete confirmation
- Added snackbar for successful or failed delete message

`material-type.componenet.ts`
- When delete button is clicked pass the selected cat_id to the `materials.service.ts` to use as identifier which category to delete

`materials.service.ts`

- Added deleteCategory method to connect to backend and pass the cat_id to be deleted