### PR TITLE
add backend logic for fetching analytics card details

### DIFF
--- a/controller_lis/fetch_analytics_card_details.php
+++ b/controller_lis/fetch_analytics_card_details.php
@@ -1,0 +1,77 @@
+<?php
+include 'db_connection.php';
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+try {
+    // Initialize the response array
+    $response = [];
+
+    // SQL query to fetch the total number of users
+    $sql_total_users = "SELECT COUNT(*) as total_users FROM users";
+    $result_total_users = $conn->query($sql_total_users);
+
+    if ($result_total_users) {
+        $response['total_users'] = $result_total_users->fetch_assoc()['total_users'];
+    } else {
+        throw new Exception('Error fetching total users.');
+    }
+
+    // SQL query to fetch the total number of users for each user_type
+    $sql_user_type_counts = "SELECT user_type, COUNT(*) as user_count FROM users GROUP BY user_type";
+    $result_user_types = $conn->query($sql_user_type_counts);
+
+    $user_type_counts = [];
+    if ($result_user_types) {
+        while ($row = $result_user_types->fetch_assoc()) {
+            $user_type_counts[$row['user_type']] = $row['user_count'];
+        }
+        $response['user_type_counts'] = $user_type_counts;
+    } else {
+        throw new Exception('Error fetching user type counts.');
+    }
+
+    // SQL query to fetch the total number of materials (sum of the counter column)
+    $sql_total_materials = "SELECT SUM(counter) as total_materials FROM category";
+    $result_total_materials = $conn->query($sql_total_materials);
+
+    if ($result_total_materials) {
+        $response['total_materials'] = $result_total_materials->fetch_assoc()['total_materials'];
+    } else {
+        throw new Exception('Error fetching total materials.');
+    }
+
+    // SQL query to fetch the total number of materials for each mat_type
+    $sql_category_counts = "SELECT mat_type, SUM(counter) as material_count FROM category GROUP BY mat_type";
+    $result_category_counts = $conn->query($sql_category_counts);
+
+    $category_counts = [];
+    if ($result_category_counts) {
+        while ($row = $result_category_counts->fetch_assoc()) {
+            $category_counts[$row['mat_type']] = $row['material_count'];
+        }
+        $response['category_counts'] = $category_counts;
+    } else {
+        throw new Exception('Error fetching category counts.');
+    }
+
+    // Send the final combined response
+    echo json_encode($response);
+
+} catch (Exception $e) {
+    echo json_encode(['error' => $e->getMessage()]);
+}
+
+$conn->close();
+?>

--- a/controller_lis/fetch_borrow_categories.php
+++ b/controller_lis/fetch_borrow_categories.php
@@ -1,0 +1,31 @@
+<?php
+include 'db_connection.php';
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// Fetch all rows where counter is greater than 0 and order by mat_type ascending
+$sql = "SELECT * FROM category WHERE duration > 0 ORDER BY mat_type ASC";
+$result = $conn->query($sql);
+
+$categories = [];
+if ($result->num_rows > 0) {
+    while ($row = $result->fetch_assoc()) {
+        $categories[] = $row;
+    }
+}
+
+echo json_encode($categories);
+
+$conn->close();
+?>

--- a/src/app/admin/borrow/borrow.component.html
+++ b/src/app/admin/borrow/borrow.component.html
@@ -44,10 +44,11 @@
         tabindex="0"
         class="dropdown-content menu bg-secondary rounded-box z-[1] w-52 p-2 shadow text-lg font-medium text-black"
       >
-        <li><a (click)="CategoryPlaceholder('Filipiñana')">Filipiñana</a></li>
-        <li><a (click)="CategoryPlaceholder('Circulation')">Circulation</a></li>
-        <li><a (click)="CategoryPlaceholder('Fiction')">Fiction</a></li>
-        <li><a (click)="CategoryPlaceholder('Donations')">Donations</a></li>
+        <li *ngFor="let category of categories">
+          <a (click)="CategoryPlaceholder(category.mat_type)">
+            {{ category.mat_type }}
+          </a>
+        </li>
       </ul>
     </div>
   </div>
@@ -57,56 +58,83 @@
       <table class="table w-full">
         <thead>
           <tr class="text-primary text-center text-sm">
-            <th>Accession No.</th>
-            <th>Title</th>
-            <th>Author</th>
-            <th>Subject</th>
-            <th>Copyright</th>
-            <th>Call number</th>
+            <th (click)="sortMaterials('accnum')">Accession No.
+              <span *ngIf="sortField === 'accnum'" class="sort-arrow">
+                <ng-container *ngIf="sortOrder === 'ASC'">↑</ng-container>
+                <ng-container *ngIf="sortOrder === 'DESC'">↓</ng-container>
+              </span>
+            </th>
+            <th (click)="sortMaterials('title')">Title
+              <span *ngIf="sortField === 'title'" class="sort-arrow">
+                <ng-container *ngIf="sortOrder === 'ASC'">↑</ng-container>
+                <ng-container *ngIf="sortOrder === 'DESC'">↓</ng-container>
+              </span>
+            </th>
+            <th (click)="sortMaterials('author')">Author
+              <span *ngIf="sortField === 'author'" class="sort-arrow">
+                <ng-container *ngIf="sortOrder === 'ASC'">↑</ng-container>
+                <ng-container *ngIf="sortOrder === 'DESC'">↓</ng-container>
+              </span>
+            </th>
+            <th (click)="sortMaterials('subj')">Subject
+              <span *ngIf="sortField === 'subj'" class="sort-arrow">
+                <ng-container *ngIf="sortOrder === 'ASC'">↑</ng-container>
+                <ng-container *ngIf="sortOrder === 'DESC'">↓</ng-container>
+              </span>
+            </th>
+            <th (click)="sortMaterials('copyright')">Copyright
+              <span *ngIf="sortField === 'copyright'" class="sort-arrow">
+                <ng-container *ngIf="sortOrder === 'ASC'">↑</ng-container>
+                <ng-container *ngIf="sortOrder === 'DESC'">↓</ng-container>
+              </span>
+            </th>
+            <th (click)="sortMaterials('callno')">Call number
+              <span *ngIf="sortField === 'callno'" class="sort-arrow">
+                <ng-container *ngIf="sortOrder === 'ASC'">↑</ng-container>
+                <ng-container *ngIf="sortOrder === 'DESC'">↓</ng-container>
+              </span>
+            </th>
             <th>Status</th>
           </tr>
         </thead>
         <tbody class="text-start text-sm">
-          @for (material of materials; track $index) {
-            <tr>
-              <td>{{ material.accnum }}</td>
-              <td>
-                <a [routerLink]="['/borrow-info', material.accnum]" 
-                   class="text-primary font-semibold hover:text-[#ffb700] 
-                          hover:underline">
-                  {{ material.title | slice:0:40 }}{{ material.title.length > 40 ? '...' : '' }}
-                </a>
-              </td>
-              <td>{{ material.author | slice:0:50 }}{{ material.author.length > 50 ? '...' : '' }}</td>
-              <td>{{ material.subj }}</td>
-              <td>{{ material.copyright }}</td>
-              <td>{{ material.callno | slice:0:11 }}{{ material.callno.length > 11 ? '...' : '' }}</td>
-              <td>{{ material.status }}</td>
-            </tr>
-          }
+          <tr *ngFor="let material of materials; trackBy: trackByAccNum">
+            <td>{{ material.accnum }}</td>
+            <td>
+              <a [routerLink]="['/borrow-info', material.accnum]"
+                 class="text-primary font-semibold hover:text-[#ffb700] hover:underline">
+                {{ material.title | slice: 0: 40 }}{{ material.title.length > 40 ? '...' : '' }}
+              </a>
+            </td>
+            <td>{{ material.author | slice: 0: 50 }}{{ material.author.length > 50 ? '...' : '' }}</td>
+            <td>{{ material.subj }}</td>
+            <td>{{ material.copyright }}</td>
+            <td>{{ material.callno | slice: 0: 11 }}{{ material.callno.length > 11 ? '...' : '' }}</td>
+            <td>{{ material.status }}</td>
+          </tr>
         </tbody>
       </table>
     </div>
-    
+
     <div class="flex justify-between items-center mt-4">
-      <span class="text-lg font-medium ml-3"
-        >Page {{ currentPage }} / {{ totalPages }}
+      <span class="text-lg font-medium ml-3">
+        Page {{ currentPage }} / {{ totalPages }}
       </span>
       <div class="flex gap-2">
         <button
-        class="btn bg-primary text-white hover:bg-primary-focus hover:bg-[#ffb700] hover:text-black"
-        [disabled]="currentPage === 1"
-        (click)="onPageChange(currentPage - 1)"
-      >
-        Previous
-      </button>
-      <button
-        class="btn bg-primary text-white hover:bg-primary-focus hover:bg-[#ffb700] hover:text-black"
-        [disabled]="currentPage === totalPages"
-        (click)="onPageChange(currentPage + 1)"
-      >
-        Next
-      </button>
+          class="btn bg-primary text-white hover:bg-primary-focus hover:bg-[#ffb700] hover:text-black"
+          [disabled]="currentPage === 1"
+          (click)="onPageChange(currentPage - 1)"
+        >
+          Previous
+        </button>
+        <button
+          class="btn bg-primary text-white hover:bg-primary-focus hover:bg-[#ffb700] hover:text-black"
+          [disabled]="currentPage === totalPages"
+          (click)="onPageChange(currentPage + 1)"
+        >
+          Next
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/admin/borrow/borrow.component.ts
+++ b/src/app/admin/borrow/borrow.component.ts
@@ -16,9 +16,12 @@ export class BorrowComponent implements OnInit {
   itemsPerPage: number = 13;
   searchTerm: string = '';
   category: string = '';
+  categories: any[] = []; // Added categories array to store category data
   private searchTerms = new Subject<string>();
 
   categoryPlaceholder: string = 'Choose category';
+  sortField: string = 'date_added'; // Default sort field
+  sortOrder: string = 'DESC'; // Default sort order
 
   constructor(private borrowService: BorrowService) {}
 
@@ -27,76 +30,95 @@ export class BorrowComponent implements OnInit {
     this.searchTerms.pipe(
       debounceTime(300),
       distinctUntilChanged(),
-      switchMap(term => {
-        if (this.category) {
-          return this.borrowService.searchBorrowableMaterialsByCategory(
-            term, 
-            this.category, 
-            this.currentPage, 
-            this.itemsPerPage
-          );
-        } else {
-          return this.borrowService.searchBorrowableMaterials(
-            term, 
-            this.currentPage, 
-            this.itemsPerPage
-          );
-        }
-      })
+      switchMap(term => this.getMaterials(term))
     ).subscribe(response => {
       this.materials = response.data;
       this.totalItems = response.totalItems;
       this.totalPages = response.totalPages;
     });
+
+    // Fetch categories when the component initializes
+    this.borrowService.getCategories().subscribe(response => {
+      this.categories = response; // Assuming the API returns a list of categories
+    });
+  }
+
+  trackByAccNum(index: number, material: any): string {
+    return material.accnum;
   }
 
   loadMaterials() {
     if (this.searchTerm) {
       if (this.category) {
-        this.borrowService.searchBorrowableMaterialsByCategory(
+        this.borrowService.searchBorrowedMaterialsByCategory(
           this.searchTerm, 
           this.category, 
           this.currentPage, 
-          this.itemsPerPage
-        )
-          .subscribe(response => {
-            this.materials = response.data;
-            this.totalItems = response.totalItems;
-            this.totalPages = response.totalPages;
-          });
+          this.itemsPerPage, 
+          this.sortField, 
+          this.sortOrder
+        ).subscribe(response => {
+          this.materials = response.data;
+          this.totalItems = response.totalItems;
+          this.totalPages = response.totalPages;
+        });
       } else {
-        this.borrowService.searchBorrowableMaterials(
+        this.borrowService.searchBorrowedMaterials(
           this.searchTerm, 
           this.currentPage, 
-          this.itemsPerPage
-        )
-          .subscribe(response => {
-            this.materials = response.data;
-            this.totalItems = response.totalItems;
-            this.totalPages = response.totalPages;
-          });
+          this.itemsPerPage, 
+          this.sortField, 
+          this.sortOrder
+        ).subscribe(response => {
+          this.materials = response.data;
+          this.totalItems = response.totalItems;
+          this.totalPages = response.totalPages;
+        });
       }
     } else if (this.category) {
-      this.borrowService.filterBorrowableMaterialsByCategory(
+      this.borrowService.filterBorrowedMaterialsByCategory(
         this.category, 
         this.currentPage, 
-        this.itemsPerPage
-      )
-        .subscribe(response => {
-          this.materials = response.data;
-          this.totalItems = response.totalItems;
-          this.totalPages = response.totalPages;
-        });
+        this.itemsPerPage, 
+        this.sortField, 
+        this.sortOrder
+      ).subscribe(response => {
+        this.materials = response.data;
+        this.totalItems = response.totalItems;
+        this.totalPages = response.totalPages;
+      });
     } else {
-      this.borrowService.getBorrowableMaterials(
+      this.borrowService.getBorrowedMaterials(
         this.currentPage, 
-        this.itemsPerPage
-      )
-        .subscribe(response => {
-          this.materials = response.data;
-          this.totalItems = response.totalItems;
-          this.totalPages = response.totalPages;
-        });
+        this.itemsPerPage, 
+        this.sortField, 
+        this.sortOrder
+      ).subscribe(response => {
+        this.materials = response.data;
+        this.totalItems = response.totalItems;
+        this.totalPages = response.totalPages;
+      });
+    }
+  }
+
+  getMaterials(term: string) {
+    if (this.category) {
+      return this.borrowService.searchBorrowedMaterialsByCategory(
+        term, 
+        this.category, 
+        this.currentPage, 
+        this.itemsPerPage, 
+        this.sortField, 
+        this.sortOrder
+      );
+    } else {
+      return this.borrowService.searchBorrowedMaterials(
+        term, 
+        this.currentPage, 
+        this.itemsPerPage, 
+        this.sortField, 
+        this.sortOrder
+      );
     }
   }
 
@@ -113,6 +135,31 @@ export class BorrowComponent implements OnInit {
   CategoryPlaceholder(value: string) {
     this.categoryPlaceholder = value;
     this.category = this.mapCategoryToAccessionNumber(value);
+    this.currentPage = 1;
+    this.loadMaterials();
+  }
+
+  mapCategoryToAccessionNumber(category: string): string {
+    const matchedCategory = this.categories.find(cat => cat.mat_type === category);
+    return matchedCategory ? matchedCategory.accession_no : '';
+  }
+
+  sortMaterials(field: string) {
+    if (field === 'accnum') {
+      // Special case for sorting by 'Acc No.'
+      this.sortField = 'categoryid';
+      this.sortOrder = this.sortOrder === 'ASC' ? 'DESC' : 'ASC';
+    } else {
+      if (this.sortField === field) {
+        // Toggle the sorting order for the same field
+        this.sortOrder = this.sortOrder === 'ASC' ? 'DESC' : 'ASC';
+      } else {
+        this.sortField = field;
+        this.sortOrder = 'DESC';
+      }
+    }
+
+    // Reload materials with the updated sorting
     this.loadMaterials();
   }
 
@@ -121,16 +168,8 @@ export class BorrowComponent implements OnInit {
     this.category = '';
     this.currentPage = 1;
     this.categoryPlaceholder = 'Choose category';
+    this.sortField = 'date_added'; // Reset to default sort field
+    this.sortOrder = 'DESC'; // Reset to default sort order
     this.loadMaterials();
-  }
-
-  mapCategoryToAccessionNumber(category: string): string {
-    const categoryMap = {
-      'Filipiñana': 'PUPT Fili',
-      'Circulation': 'PUPT Circ',
-      'Fiction': 'PUPT Fic',
-      'Donations': 'PUPT Don',
-    };
-    return categoryMap[category] || '';
   }
 }

--- a/src/app/admin/materials/materials.component.html
+++ b/src/app/admin/materials/materials.component.html
@@ -76,33 +76,6 @@
       </div>
     </div>
     <div class="p-4 bg-white text-black rounded-xl w-full mb-4 slide-in-right">
-
-        <!-- <div class="flex justify-between items-center mx-3">
-          <span class="text-lg font-medium text-black"
-            >Page {{ currentPage }} / {{ totalPages }}</span>
-      
-          <div class="flex gap-2">
-            <button
-            class="btn bg-secondary text-black hover:bg-primary-focus hover:bg-[#801E1D] hover:text-white"
-            [disabled]="currentPage === 1"
-            (click)="onPageChange(currentPage - 1)"
-          >
-            Previous
-          </button>
-      
-          <button
-            class="btn bg-secondary text-black hover:bg-primary-focus hover:bg-[#801E1D] hover:text-white"
-            [disabled]="currentPage === totalPages"
-            (click)="onPageChange(currentPage + 1)"
-          >
-            Next
-          </button>
-          </div>
-      
-        </div>
-    
-        <div class="divider my-0"></div> -->
-    
         <div class="overflow-x-auto">
           <table class="table w-full">
             <thead>
@@ -147,21 +120,6 @@
               </tr>
           </thead>
             <tbody class="text-start text-sm">
-              <!-- <tr *ngFor="let material of materials">
-                <td>{{ material.accnum }}</td>
-                <td>
-                  <a [routerLink]="['/borrow-info', material.accnum]" 
-                     class="text-primary font-semibold hover:text-[#ffb700] 
-                            hover:underline">
-                    {{ material.title | slice:0:48 }}{{ material.title.length > 48 ? '...' : '' }}
-                  </a>
-                </td>
-                <td>{{ material.author | slice:0:70 }}{{ material.author.length > 70 ? '...' : '' }}</td>
-                <td>{{ material.subj }}</td>
-                <td>{{ material.copyright }}</td>
-                <td>{{ material.callno | slice:0:12 }}{{ material.callno.length > 12 ? '...' : '' }}</td>
-                <td>{{ material.status }}</td>
-              </tr> -->
               @for (material of materials; track $index) {
                 <tr>
                   <td>{{ material.accnum }}</td>

--- a/src/app/admin/materials/materials.component.ts
+++ b/src/app/admin/materials/materials.component.ts
@@ -201,5 +201,4 @@ export class MaterialsComponent {
     // Reload materials with the updated sorting
     this.loadMaterials();
   }
-  
 }

--- a/src/app/client/search-book/search-book.component.ts
+++ b/src/app/client/search-book/search-book.component.ts
@@ -181,15 +181,21 @@ export class SearchBookComponent implements OnInit {
   }
 
   sortMaterials(field: string) {
-    if (this.sortField === field) {
-      // Toggle sort order if the same field is clicked
+    if (field === 'accnum') {
+      // Special case for sorting by 'Acc No.'
+      this.sortField = 'categoryid';
       this.sortOrder = this.sortOrder === 'ASC' ? 'DESC' : 'ASC';
     } else {
-      // Set new sort field and default sort order to DESC
-      this.sortField = field;
-      this.sortOrder = 'DESC';
+      if (this.sortField === field) {
+        // Toggle the sorting order for the same field
+        this.sortOrder = this.sortOrder === 'ASC' ? 'DESC' : 'ASC';
+      } else {
+        this.sortField = field;
+        this.sortOrder = 'DESC';
+      }
     }
-    
+
+    // Reload materials with the updated sorting
     this.loadMaterials();
   }
 }

--- a/src/services/borrow.service.ts
+++ b/src/services/borrow.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from './environments/local-environment';
 
@@ -9,26 +9,75 @@ export class BorrowService {
 
   constructor(private http: HttpClient) {}
 
-  getBorrowableMaterials(page: number, limit: number): Observable<any> {
-    return this.http.get<any>(`${this.apiUrl}/fetch_borrowable_materials.php?page=${page}&limit=${limit}`);
-  }
-
-  searchBorrowableMaterials(term: string, page: number, limit: number): Observable<any> {
-    return this.http.get<any>(`${this.apiUrl}/fetch_borrowable_materials.php?search=${term}&page=${page}&limit=${limit}`);
-  }
-
-  filterBorrowableMaterialsByCategory(category: string, page: number, limit: number): Observable<any> {
-    return this.http.get<any>(`${this.apiUrl}/fetch_borrowable_materials.php?category=${category}&page=${page}&limit=${limit}`);
-  }
-
-  searchBorrowableMaterialsByCategory(term: string, category: string, page: number, limit: number): Observable<any> {
-    return this.http.get<any>(`${this.apiUrl}/fetch_borrowable_materials.php?search=${term}&category=${category}&page=${page}&limit=${limit}`);
-  }
-
+  // Add the missing borrowBook method
   borrowBook(idNumber: string, materialId: number): Observable<any> {
     return this.http.post<any>(`${this.apiUrl}/borrow_book.php`, {
       id_number: idNumber,
       material_id: materialId
     });
+  }
+
+  getBorrowedMaterials(page: number, limit: number, sortField?: string, sortOrder?: string): Observable<any> {
+    let params = new HttpParams()
+      .set('page', page.toString())
+      .set('limit', limit.toString())
+      .set('sortField', sortField || 'date_borrowed') // Default sortField set to 'date_borrowed'
+      .set('sortOrder', sortOrder || 'DESC'); // Default sortOrder set to 'DESC'
+
+    console.log('getBorrowedMaterials payload:', params.toString());
+    return this.http.get<any>(`${this.apiUrl}/fetch_borrowable_materials.php`, { params });
+  }
+
+  searchBorrowedMaterials(term: string, page: number, limit: number, sortField?: string, sortOrder?: string): Observable<any> {
+    let params = new HttpParams()
+      .set('search', term)
+      .set('page', page.toString())
+      .set('limit', limit.toString())
+      .set('sortField', sortField || 'date_borrowed')
+      .set('sortOrder', sortOrder || 'DESC');
+
+    console.log('searchBorrowedMaterials payload:', params.toString());
+    return this.http.get<any>(`${this.apiUrl}/fetch_borrowable_materials.php`, { params });
+  }
+
+  filterBorrowedMaterialsByCategory(category: string, page: number, limit: number, sortField?: string, sortOrder?: string): Observable<any> {
+    let params = new HttpParams()
+      .set('category', category)
+      .set('page', page.toString())
+      .set('limit', limit.toString())
+      .set('sortField', sortField || 'date_borrowed')
+      .set('sortOrder', sortOrder || 'DESC');
+
+    console.log('filterBorrowedMaterialsByCategory payload:', params.toString());
+    return this.http.get<any>(`${this.apiUrl}/fetch_borrowable_materials.php`, { params });
+  }
+
+  searchBorrowedMaterialsByCategory(term: string, category: string, page: number, limit: number, sortField?: string, sortOrder?: string): Observable<any> {
+    let params = new HttpParams()
+      .set('search', term)
+      .set('category', category)
+      .set('page', page.toString())
+      .set('limit', limit.toString())
+      .set('sortField', sortField || 'date_borrowed')
+      .set('sortOrder', sortOrder || 'DESC');
+
+    console.log('searchBorrowedMaterialsByCategory payload:', params.toString());
+    return this.http.get<any>(`${this.apiUrl}/fetch_borrowable_materials.php`, { params });
+  }
+
+  getBorrowedMaterialDetails(borrow_id: string): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}/fetch_borrowed_material_details.php?borrow_id=${borrow_id}`);
+  }
+
+  updateBorrowedMaterial(borrowedMaterial: any): Observable<any> {
+    return this.http.post<any>(`${this.apiUrl}/update_borrowed_material.php`, borrowedMaterial);
+  }
+
+  deleteBorrowedMaterial(borrow_id: string): Observable<any> {
+    return this.http.post<any>(`${this.apiUrl}/delete_borrowed_material.php`, { borrow_id });
+  }
+
+  getCategories(): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}/fetch_borrow_categories.php`);
   }
 }


### PR DESCRIPTION
`fetch_analytics_card_details.php`

- Backend logic for fetching the details to be displayed on the analytics page cards
  - Total number of users
  - Total number of user per user_type
  - Total number of materials
  - Total number of materials per category

`fetch_borrow_categories.php`
- Backend logic for fetching the borrowable material categories form the category table
   - This is determined by checking the duration column, if it is > 0, fetch that category

`fetch_borrowable_materials.php`

- Updated to be able to handle sorting by the selected headers

`borrow.component`

 - Updated headers to be clickable as the trigger for sorting
 - Updated category dropdown to be dynamic instead of hard coded
 - Searching or filtering by category works with the sort filters

`Borrow Service`

- Updated the methods for fetching, searching and filtering by category to work with the sorting feature.

