### PR TITLE
fix bug where category details not showing for material-info page

### DIFF
--- a/src/app/client/material-info/material-info.component.ts
+++ b/src/app/client/material-info/material-info.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MaterialsService } from '../../../services/materials.service';
 import { Location } from '@angular/common';
+
 @Component({
   selector: 'app-material-info',
   templateUrl: './material-info.component.html',
@@ -9,6 +10,7 @@ import { Location } from '@angular/common';
 })
 export class MaterialInfoComponent {
   material: any = {};
+  categories: { cat_id: number, mat_type: string }[] = [];
 
   constructor(private route: ActivatedRoute, 
               private materialsService: MaterialsService, 
@@ -17,9 +19,15 @@ export class MaterialInfoComponent {
   ngOnInit(): void {
     const accnum = this.route.snapshot.paramMap.get('accnum');
     if (accnum) {
+      // Fetch material details
       this.materialsService.getMaterialDetails(accnum).subscribe(data => {
         this.material = data;
         this.populateForm();
+      });
+
+      // Fetch categories (assuming you have a method to fetch categories)
+      this.materialsService.getCategories().subscribe(cats => {
+        this.categories = cats;
       });
     }
   }
@@ -29,11 +37,12 @@ export class MaterialInfoComponent {
   }
 
   populateForm(): void {
-    // Populate form fields with material data, set default value to "unknown/empty" if field is empty
+    console.log('CAT ID:', this.material.categoryid);
+
+    // Populate form fields with material data
     this.material.title = this.material.title || 'unknown/empty';
     this.material.subj = this.material.subj || 'unknown/empty';
     this.material.accnum = this.material.accnum || 'unknown/empty';
-    this.material.category = this.material.category || 'unknown/empty';
     this.material.author = this.material.author || 'unknown/empty';
     this.material.callno = this.material.callno || 'unknown/empty';
     this.material.copyright = this.material.copyright || 'unknown/empty';
@@ -41,6 +50,13 @@ export class MaterialInfoComponent {
     this.material.edition = this.material.edition || 'unknown/empty';
     this.material.isbn = this.material.isbn || 'unknown/empty';
     this.material.status = this.material.status || 'unknown/empty';
+
+    // Find the matching category by categoryid and assign the mat_type
+    const matchingCategory = this.categories.find(cat => cat.cat_id === this.material.categoryid);
+    if (matchingCategory) {
+      this.material.category = matchingCategory.mat_type;
+    } else {
+      this.material.category = 'unknown/empty'; 
+    }
   }
 }
-


### PR DESCRIPTION
Added method to use the **_categoryid_** value received from the material table, then convert it to the corresponding **_mat_type_** to successfully display the category name for each material.