### PR TITLE
vertical scrolling in category and subject dropdowns, date of registration, course and department in user logs

### DIFF
--- a/src/app/admin/materials-add/materials-add.component.html
+++ b/src/app/admin/materials-add/materials-add.component.html
@@ -53,7 +53,7 @@
           <div class="w-1/2 flex mt-1">
             <input id="category" name="category" type="hidden" [(ngModel)]="bookDetails.category" #categoryInput="ngModel" required />
             <div class="flex-1 relative">
-              <div class="dropdown dropdown-left w-full">
+              <div class="dropdown dropdown-bottom w-full">
                 <div tabindex="0" role="button"
                      class="btn w-full 
                             bg-secondary 
@@ -79,10 +79,12 @@
                 </div>
                 
                 <ul tabindex="0" *ngIf="isDropdownOpen"
-                    class="dropdown-content menu bg-secondary rounded-box z-[1] w-full text-base font-medium text-black">
+                    class="dropdown-content menu bg-secondary rounded-box z-[1] 
+                    w-full text-base font-medium text-black 
+                    max-h-60 overflow-y-auto overflow-x-hidden block">
                   <li *ngFor="let category of categories">
                     <a (click)="selectCategory(category.cat_id, category.mat_type)" 
-                       class="block px-4 py-2 hover:bg-[#ffb700] hover:text-black">
+                       class="block w-full px-4 py-2 hover:bg-[#801e1d] hover:text-white">
                       {{ category.mat_type }}
                     </a>
                   </li>
@@ -137,7 +139,7 @@
                    [(ngModel)]="bookDetails.heading" 
                    #headingInput="ngModel" required />
             <div class="flex-1 relative">
-              <div class="dropdown dropdown-left w-full">
+              <div class="dropdown dropdown-bottom w-full">
                 <div tabindex="0" role="button"
                      class="btn w-full 
                             bg-secondary 
@@ -158,13 +160,15 @@
                     <span class="tooltip" id="heading_tooltip">Please select a subject heading.</span>
                   </span>
                 </div>
-
+          
+                <!-- Updated dropdown with vertical stacking and scrolling -->
                 <ul tabindex="0" *ngIf="isSubjectDropdownOpen"
                     class="dropdown-content menu bg-secondary rounded-box z-[1] 
-                           w-full text-base font-medium text-black">
-                  <li *ngFor="let subject of subjects">
+                           w-full text-base font-medium text-black 
+                           max-h-56 overflow-y-auto overflow-x-hidden block">
+                  <li *ngFor="let subject of subjects" class="w-full">
                     <a (click)="selectSubjectHeading(subject.id, subject.subject_name)" 
-                       class="block px-4 py-2 hover:bg-[#ffb700] hover:text-black">
+                       class="block w-full px-4 py-2 hover:bg-[#801e1d] hover:text-white">
                       {{ subject.subject_name }}
                     </a>
                   </li>
@@ -172,7 +176,7 @@
               </div>
             </div>
           </div>
-          
+                    
         </div>
 
         <div class="mb-4 mt-1 flex items-center space-x-4">

--- a/src/app/admin/materials-type/materials-type.component.html
+++ b/src/app/admin/materials-type/materials-type.component.html
@@ -30,6 +30,24 @@
         </tbody>
       </table>
     </div>
+    <div class="divider my-0"></div>
+    <div class="flex justify-between items-center gap-5 slide-in-right">
+      <span class="text-lg font-medium ml-3 text-black">
+        Page 1 / 
+      </span>
+      <div class="flex gap-2">
+        <button
+          class="btn border-none bg-primary text-white hover:bg-primary-focus hover:bg-[#ffb700] hover:text-black"
+        >
+          Previous
+        </button>
+        <button
+          class="btn border-none bg-primary text-white hover:bg-primary-focus hover:bg-[#ffb700] hover:text-black"
+        >
+          Next
+        </button>
+        </div>
+    </div>
   </div>
   <div class="w-full lg:w-1/3 flex flex-col items-center">
     <div class="bg-white p-6 lg:p-8 pb-0 rounded-xl shadow-lg w-full lg:w-4/5 slide-in-right">
@@ -39,7 +57,7 @@
       <span class="text-primary text-2xl font-medium">{{ totalCount }}</span>
       <div class="divider my-0"></div>
       <span class="text-start text-2xl font-normal text-black mb-3">
-        Total library materials types:
+        Total library material types:
       </span>
       <span class="text-primary text-2xl font-medium">14</span>
       <div class="divider my-0"></div>

--- a/src/app/admin/records/records.component.html
+++ b/src/app/admin/records/records.component.html
@@ -121,6 +121,7 @@
                 <th class="text-start">Course</th>
                 <th class="text-start">Phone Number</th>
                 <th class="text-start">Email</th>
+                <th class="text-start">Date of Registration</th>
               </tr>
             </thead>
             <tbody class="text-start">
@@ -131,6 +132,7 @@
                 <td>{{ record.course }}</td>
                 <td>{{ record.phone_number }}</td>
                 <td>{{ record.email }}</td>
+                <td>sample-date</td>
               </tr>
             </tbody>
           </table>
@@ -152,6 +154,7 @@
                 <th class="text-start">Department</th>
                 <th class="text-start">Phone Number</th>
                 <th class="text-start">Email</th>
+                <th class="text-start">Date of Registration</th>
               </tr>
             </thead>
             <tbody class="text-start">
@@ -169,6 +172,7 @@
                 <td>{{ record.department }}</td>
                 <td>{{ record.phone_number }}</td>
                 <td>{{ record.email }}</td>
+                <td>sample-date</td>
               </tr>
             </tbody>
           </table>
@@ -181,6 +185,7 @@
                 <th class="text-start">Gender</th>
                 <th class="text-start">Phone Number</th>
                 <th class="text-start">School</th>
+                <th class="text-start">Date of Registration</th>
               </tr>
             </thead>
             <tbody class="text-start">
@@ -189,6 +194,7 @@
                 <td>{{ record.gender }}</td>
                 <td>{{ record.phone_number }}</td>
                 <td>{{ record.school }}</td>
+                <td>sample-date</td>
               </tr>
             </tbody>
           </table>

--- a/src/app/super-admin/user-record/user-record.component.html
+++ b/src/app/super-admin/user-record/user-record.component.html
@@ -88,6 +88,7 @@
               <tr class="text-primary text-sm">
                 <th class="text-start">Student Number</th>
                 <th class="text-start">Name</th>
+                <th class="text-start">Course</th>
                 <th class="text-start">Time In</th>
                 <th class="text-start">Time Out</th>
               </tr>
@@ -96,6 +97,7 @@
               <tr *ngFor="let log of logs">
                 <td>{{ log.student_number }}</td>
                 <td>{{ log.name }}</td>
+                <td>sample-course (BSIT)</td>
                 <td>{{ log.time_in }}</td>
                 <td>{{ log.time_out || 'await' }}</td>
               </tr>
@@ -108,6 +110,7 @@
               <tr class="text-primary text-sm">
                 <th class="text-start">Faculty Code</th>
                 <th class="text-start">Name</th>
+                <th class="text-start">Department</th>
                 <th class="text-start">Time In</th>
                 <th class="text-start">Time Out</th>
               </tr>
@@ -116,6 +119,7 @@
               <tr *ngFor="let log of logs">
                 <td>{{ log.faculty_code }}</td>
                 <td>{{ log.name }}</td>
+                <td>sample-department (IT)</td>
                 <td>{{ log.time_in }}</td>
                 <td>{{ log.time_out || 'await' }}</td>
               </tr>


### PR DESCRIPTION
- make the category and subject heading dropdowns to scroll of maximum height is reached

![image](https://github.com/user-attachments/assets/a6b74a5b-5533-4b07-9889-03c213c3ecdf)

![image](https://github.com/user-attachments/assets/66390459-6420-48b6-baa9-43c778889cbd)

- add date of registration column in user records

![image](https://github.com/user-attachments/assets/16fe8f4e-17fd-4e3c-a15f-0488e3abacd2)

- add course and department column in student and faculty logs

![image](https://github.com/user-attachments/assets/9ef5ff5d-67d3-42f2-911c-d2e58e642b74)

![image](https://github.com/user-attachments/assets/81b35238-7f04-4ab5-8680-aebd45ec43b3)


- add pagination in material types:
![image](https://github.com/user-attachments/assets/7e693c32-cd86-44b8-bd99-3abbb5f0ad16)
