### PR TITLE
Implement searchable dropdown for subjects in add material page

### DIFF
--- a/controller_lis/fetch_subjects.php
+++ b/controller_lis/fetch_subjects.php
@@ -14,9 +14,20 @@ if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-// Fetch all details from the subject table
-$sql = "SELECT * FROM subjects";
-$stmt = $conn->prepare($sql);
+// Fetch the search term from the query parameter, if provided
+$searchTerm = isset($_GET['searchTerm']) ? $_GET['searchTerm'] : '';
+
+// Modify the SQL query to filter by the search term if it exists
+if (!empty($searchTerm)) {
+    $sql = "SELECT * FROM subjects WHERE subject_name LIKE ?";
+    $stmt = $conn->prepare($sql);
+    $searchTerm = '%' . $searchTerm . '%'; // Add wildcards for partial matching
+    $stmt->bind_param("s", $searchTerm);
+} else {
+    $sql = "SELECT * FROM subjects";
+    $stmt = $conn->prepare($sql);
+}
+
 $stmt->execute();
 $result = $stmt->get_result();
 

--- a/src/app/admin/materials-add/materials-add.component.html
+++ b/src/app/admin/materials-add/materials-add.component.html
@@ -133,49 +133,43 @@
               </span>
           </div>
 
-          <!-- Subject Heading -->
-          <div class="w-1/2 flex mt-1">
-            <input id="heading" name="heading" type="hidden" 
-                   [(ngModel)]="bookDetails.heading" 
-                   #headingInput="ngModel" required />
-            <div class="flex-1 relative">
-              <div class="dropdown dropdown-bottom w-full">
-                <div tabindex="0" role="button"
-                     class="btn w-full 
-                            bg-secondary 
-                            border-none 
-                            text-black 
-                            text-lg 
-                            hover:bg-[#ffb700] 
-                            rounded-box 
-                            flex items-center 
-                            justify-between"
-                     (click)="toggleSubjectDropdown()"
-                     (blur)="headingInput.control.markAsTouched()">
-                  <span>{{ selectedSubject?.subject_name || 'Select subject heading' }}</span>
-              
-                  <!-- Exclamation icon shown if subject heading is invalid -->
-                  <span *ngIf="headingInput.invalid && headingInput.touched" class="flex items-center">
-                    <img src="../../../assets/Exclamation_flat_icon.svg.png" alt="Exclamation Mark" class="h-4 w-4"/>
-                    <span class="tooltip" id="heading_tooltip">Please select a subject heading.</span>
-                  </span>
-                </div>
-          
-                <!-- Updated dropdown with vertical stacking and scrolling -->
-                <ul tabindex="0" *ngIf="isSubjectDropdownOpen"
-                    class="dropdown-content menu bg-secondary rounded-box z-[1] 
-                           w-full text-base font-medium text-black 
-                           max-h-56 overflow-y-auto overflow-x-hidden block">
-                  <li *ngFor="let subject of subjects" class="w-full">
-                    <a (click)="selectSubjectHeading(subject.id, subject.subject_name)" 
-                       class="block w-full px-4 py-2 hover:bg-[#801e1d] hover:text-white">
-                      {{ subject.subject_name }}
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
+ <!-- Subject Heading -->
+<div class="w-1/2 flex mt-1">
+  <input id="heading" name="heading" type="hidden" [(ngModel)]="bookDetails.heading" #headingInput="ngModel" required />
+  <div class="flex-1 relative">
+    <div class="dropdown dropdown-bottom w-full">
+      <div tabindex="0" role="button"
+           class="btn w-full bg-secondary border-none text-black text-lg hover:bg-[#ffb700] rounded-box flex items-center justify-between"
+           (click)="toggleSubjectDropdown()"
+           (blur)="headingInput.control.markAsTouched()">
+        <span>{{ selectedSubject?.subject_name || 'Select subject heading' }}</span>
+
+        <!-- Exclamation icon shown if subject heading is invalid -->
+        <span *ngIf="headingInput.invalid && headingInput.touched" class="flex items-center">
+          <img src="../../../assets/Exclamation_flat_icon.svg.png" alt="Exclamation Mark" class="h-4 w-4"/>
+          <span class="tooltip" id="heading_tooltip">Please select a subject heading.</span>
+        </span>
+      </div>
+
+      <!-- Dropdown with search input -->
+      <div *ngIf="isSubjectDropdownOpen" class="dropdown-content menu bg-secondary rounded-box z-[1] w-full text-base font-medium text-black max-h-56 overflow-y-auto overflow-x-hidden block">
+        <!-- Search input -->
+        <input type="text" placeholder="Search subject..." class="input input-bordered w-full mb-2"
+        name="subjectSearch"[(ngModel)]="subjectSearchTerm" (ngModelChange)="onSubjectSearch($event)" />
+
+        <!-- Subject list -->
+        <ul tabindex="0">
+          <li *ngFor="let subject of filteredSubjects" class="w-full">
+            <a (click)="selectSubjectHeading(subject.id, subject.subject_name)" class="block w-full px-4 py-2 hover:bg-[#801e1d] hover:text-white">
+              {{ subject.subject_name }}
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
                     
         </div>
 

--- a/src/app/admin/materials-add/materials-add.component.ts
+++ b/src/app/admin/materials-add/materials-add.component.ts
@@ -45,6 +45,8 @@ export class MaterialsAddComponent {
   isSubjectDropdownOpen = false; 
   selectedSubject: { id: number, subject_name: string } | null = null;  // To display subject heading in dropdown
   subjects: { id: number, subject_name: string }[] = [];  // Holds subject ids and headings
+  filteredSubjects: { id: number, subject_name: string }[] = [];
+  subjectSearchTerm: string = ''; // To hold the search term
 
 
   ngOnInit(): void {
@@ -59,15 +61,18 @@ export class MaterialsAddComponent {
       this.selectedCategory = { cat_id: 0, mat_type: 'Select Category' };
     });
 
-        // Fetch subject headings from the database
-        this.addMaterialService.getSubjectHeadings().subscribe(data => {
-          this.subjects = data.map((subject: any) => ({
-            id: subject.id,
-            subject_name: subject.subject_name
-          }));
-    
-          this.selectedSubject = { id: 0, subject_name: 'Select Subject' };
-        });
+    this.fetchSubjects();
+  }
+
+  // Fetch subjects from the service
+  fetchSubjects(searchTerm: string = ''): void {
+    this.addMaterialService.getSubjectHeadings(searchTerm).subscribe(data => {
+      this.subjects = data.map((subject: any) => ({
+        id: subject.id,
+        subject_name: subject.subject_name
+      }));
+      this.filteredSubjects = [...this.subjects]; // Initially show all subjects
+    });
   }
 
   openConfirmModal() {
@@ -158,5 +163,10 @@ export class MaterialsAddComponent {
     this.bookDetails.heading = subject_name;  // Set the subject heading in bookDetails
     this.selectedSubject = { id, subject_name };  // Display selected heading in dropdown
     this.isSubjectDropdownOpen = false;
+  }
+  
+  // Search for subjects based on the input term
+  onSubjectSearch(term: string): void {
+    this.fetchSubjects(term); // Fetch subjects based on search term
   }
 }

--- a/src/services/add-material.service.ts
+++ b/src/services/add-material.service.ts
@@ -27,8 +27,12 @@ export class AddMaterialService {
   addBook(bookDetails: any): Observable<any> {
     return this.http.post<any>(this.addBookUrl, bookDetails);
   }
-    // Method to get subject headings
-    getSubjectHeadings(): Observable<any> {
-      return this.http.get<any>(this.getSubjectHeadingsUrl);
-    }
+  
+  // Method to get subject headings, with an optional search term
+  getSubjectHeadings(searchTerm: string = ''): Observable<any> {
+    const url = searchTerm 
+                ? `${this.getSubjectHeadingsUrl}?searchTerm=${encodeURIComponent(searchTerm)}`
+                : this.getSubjectHeadingsUrl;
+    return this.http.get<any>(url);
+  }
 }


### PR DESCRIPTION
- When the subject dropdown is clicked it should b appear with a search bar:

![image](https://github.com/user-attachments/assets/166d30aa-61eb-491c-b804-5d20d73d8093)

- The dropdown can be filtered with the input on the search bar

![image](https://github.com/user-attachments/assets/36a29a62-6efa-4244-bdd9-52ddc920000c)


- modified `controller_lis/fetch_subjects.php` to be able to filter the response based on the searchTerm passed, if none is passed it should get all rows