### PR TITLE
Modified fetching and adding subject by subject_id

### DIFF
--- a/controller_lis/add_material.php
+++ b/controller_lis/add_material.php
@@ -27,8 +27,8 @@ $edition = $data['edition'] ?? null;
 $isbn = $data['isbn'] ?? null;
 $status = $data['status'] ?? null;
 $heading = $data['heading'] ?? null;
-//$datereceived = date('Y-m-d'); // set the current date
-$subj = $heading;
+
+$subj = $heading; // Subject value from heading
 
 $conn->begin_transaction();
 
@@ -36,14 +36,15 @@ try {
     // Insert book details into the materials table
     $stmt = $conn->prepare("INSERT INTO materials (
         accnum, isbn, title, subj, callno, author, 
-        publisher, edition, copyright, copies, categoryid, status) 
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+        publisher, edition, copyright, copies, categoryid, status, subject_id) 
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
     $copies = 1; // Assuming a default value for copies, adjust as needed
 
-    $stmt->bind_param("ssssssssssis", 
+    // Include $heading as subject_id in the bind_param
+    $stmt->bind_param("ssssssssssiss", 
     $accnum, $isbn, $title, $subj, $callno, 
-    $author, $publisher, $edition, $copyright, $copies, $categoryid, $status);
+    $author, $publisher, $edition, $copyright, $copies, $categoryid, $status, $heading); // Add $heading as the last parameter
 
     $stmt->execute();
     $stmt->close();

--- a/controller_lis/db_connection.php
+++ b/controller_lis/db_connection.php
@@ -2,7 +2,7 @@
 $servername = "localhost";
 $username = "root";
 $password = "";
-$dbname = "lis";
+$dbname = "lis_sub";
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 

--- a/controller_lis/db_connection.php
+++ b/controller_lis/db_connection.php
@@ -2,7 +2,7 @@
 $servername = "localhost";
 $username = "root";
 $password = "";
-$dbname = "lis_sub";
+$dbname = "lis";
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 

--- a/controller_lis/fetch_borrowable_materials.php
+++ b/controller_lis/fetch_borrowable_materials.php
@@ -43,11 +43,13 @@ if (!in_array($sortOrder, $allowedSortOrders)) {
     $sortOrder = 'DESC'; // Default sort order
 }
 
-// Base SQL query to fetch borrowable materials
+// Base SQL query to fetch borrowable materials including subject_name
 $sql = "SELECT m.id, m.accnum, m.title, m.author, m.subj, 
-               m.copyright, m.callno, m.status, m.isbn 
+               m.copyright, m.callno, m.status, m.isbn, 
+               s.subject_name  -- Add subject_name here
         FROM materials m
         JOIN category c ON m.categoryid = c.cat_id
+        LEFT JOIN subjects s ON m.subject_id = s.id  -- Join with subjects table to fetch subject_name
         WHERE c.cat_type = 'Normal' AND c.duration > 0 
         AND (m.accnum LIKE ? 
              OR m.title LIKE ? 
@@ -93,7 +95,7 @@ $result = $stmt->get_result();
 
 $materials = array();
 while ($row = $result->fetch_assoc()) {
-    $materials[] = $row;
+    $materials[] = $row;  // This array will now contain subject_name as well
 }
 
 // Fetch total count for pagination

--- a/controller_lis/fetch_borrowing_data.php
+++ b/controller_lis/fetch_borrowing_data.php
@@ -16,7 +16,7 @@ $endDate = isset($_GET['endDate']) ? $_GET['endDate'] : null;
 $searchTerm = isset($_GET['searchTerm']) ? $_GET['searchTerm'] : '';
 $remarkFilter = isset($_GET['remark']) ? $_GET['remark'] : null;
 
-// Base SQL query to fetch data
+// Base SQL query to fetch data including subject name (subj)
 $sql = "
 SELECT 
     b.material_id,
@@ -26,6 +26,7 @@ SELECT
     b.remark,
     m.title,
     m.author,
+    m.subj as subject_name,  -- Adding subject_name
     u.user_type,
     IF(u.user_type = 'student', s.first_name, f.first_name) as first_name,
     IF(u.user_type = 'student', s.surname, f.surname) as surname,
@@ -47,6 +48,7 @@ if (!empty($searchTerm)) {
     $sql .= " AND (
         m.title LIKE '%$searchTerm%' 
         OR m.author LIKE '%$searchTerm%' 
+        OR m.subj LIKE '%$searchTerm%'  -- Add subject_name to the search filter
         OR b.remark LIKE '%$searchTerm%' 
         OR s.first_name LIKE '%$searchTerm%' 
         OR s.surname LIKE '%$searchTerm%' 
@@ -85,6 +87,7 @@ while ($row = $result->fetch_assoc()) {
     $borrowings[] = $row;
 }
 
+// Return the results as JSON including subject_name
 echo json_encode($borrowings);
 
 $conn->close();

--- a/controller_lis/fetch_material_details.php
+++ b/controller_lis/fetch_material_details.php
@@ -17,26 +17,43 @@ ini_set('display_errors', 1);
 $accnum = isset($_GET['accnum']) ? $_GET['accnum'] : '';
 
 if ($accnum) {
-    $sql = "SELECT * FROM materials WHERE accnum = ?";
+    // Modify the query to join with the subjects table to get the subject_name
+    $sql = "SELECT m.*, s.subject_name 
+            FROM materials m
+            LEFT JOIN subjects s ON m.subject_id = s.id
+            WHERE m.accnum = ?";
+    
     $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        echo json_encode(['error' => 'Failed to prepare statement: ' . $conn->error]);
+        exit;
+    }
+    
     $stmt->bind_param("s", $accnum);
     $stmt->execute();
     $result = $stmt->get_result();
     $material = $result->fetch_assoc();
 
+    // Check if material is charged and fetch borrower details
     if ($material && $material['status'] === 'Charged') {
         $sql = "SELECT b.user_id, s.student_number, f.emp_number
                 FROM borrowing b
                 LEFT JOIN students s ON b.user_id = s.user_id
                 LEFT JOIN faculty f ON b.user_id = f.user_id
                 WHERE b.material_id = ? AND b.remark = 'In Progress'";
-
+        
         $stmt = $conn->prepare($sql);
+        if (!$stmt) {
+            echo json_encode(['error' => 'Failed to prepare borrower statement: ' . $conn->error]);
+            exit;
+        }
+
         $stmt->bind_param("i", $material['id']);
         $stmt->execute();
         $result = $stmt->get_result();
         $borrower = $result->fetch_assoc();
 
+        // Set the borrower ID based on whether the user is a student or faculty
         if ($borrower) {
             if ($borrower['student_number']) {
                 $material['borrower_id'] = $borrower['student_number'];
@@ -46,6 +63,7 @@ if ($accnum) {
         }
     }
 
+    // Return material details including subject name
     echo json_encode($material);
 } else {
     echo json_encode(['error' => 'Invalid Accession Number']);

--- a/controller_lis/fetch_materials.php
+++ b/controller_lis/fetch_materials.php
@@ -52,10 +52,12 @@ if (!in_array(strtoupper($sortOrder), $allowedSortOrders)) {
     $sortOrder = 'DESC';
 }
 
-// Update the SQL query to include subject_id
-$sql = "SELECT m.id, m.accnum, m.title, m.author, m.subj, m.copyright, m.callno, m.status, m.isbn, m.date_added, c.mat_type, m.subject_id 
+// Update the SQL query to include a join with the subjects table to get subject_name
+$sql = "SELECT m.id, m.accnum, m.title, m.author, m.subj, m.copyright, m.callno, m.status, m.isbn, m.date_added, c.mat_type, 
+               s.subject_name 
         FROM materials m
         LEFT JOIN category c ON m.categoryid = c.cat_id
+        LEFT JOIN subjects s ON m.subject_id = s.id 
         WHERE (m.accnum LIKE ? OR m.title LIKE ? OR m.author LIKE ? OR m.subj LIKE ? OR m.copyright LIKE ? OR m.callno LIKE ? OR m.status LIKE ?)";
 
 if (!empty($category)) {
@@ -101,13 +103,13 @@ if (!$result) {
 
 $materials = array();
 while ($row = $result->fetch_assoc()) {
-    $materials[] = $row; // Now includes subject_id
+    $materials[] = $row; // Now includes subject_name
 }
 
 $total_sql = "SELECT COUNT(*) as count FROM materials m
               LEFT JOIN category c ON m.categoryid = c.cat_id
               WHERE (m.accnum LIKE ? OR m.title LIKE ? OR m.author LIKE ? OR m.subj LIKE ? OR m.copyright LIKE ? OR m.callno LIKE ? OR m.status LIKE ?)";
-
+              
 $total_params = [$search, $search, $search, $search, $search, $search, $search];
 if (!empty($category)) {
     $total_sql .= " AND m.accnum LIKE ?";

--- a/controller_lis/fetch_materials.php
+++ b/controller_lis/fetch_materials.php
@@ -52,7 +52,8 @@ if (!in_array(strtoupper($sortOrder), $allowedSortOrders)) {
     $sortOrder = 'DESC';
 }
 
-$sql = "SELECT m.id, m.accnum, m.title, m.author, m.subj, m.copyright, m.callno, m.status, m.isbn, m.date_added, c.mat_type 
+// Update the SQL query to include subject_id
+$sql = "SELECT m.id, m.accnum, m.title, m.author, m.subj, m.copyright, m.callno, m.status, m.isbn, m.date_added, c.mat_type, m.subject_id 
         FROM materials m
         LEFT JOIN category c ON m.categoryid = c.cat_id
         WHERE (m.accnum LIKE ? OR m.title LIKE ? OR m.author LIKE ? OR m.subj LIKE ? OR m.copyright LIKE ? OR m.callno LIKE ? OR m.status LIKE ?)";
@@ -100,7 +101,7 @@ if (!$result) {
 
 $materials = array();
 while ($row = $result->fetch_assoc()) {
-    $materials[] = $row;
+    $materials[] = $row; // Now includes subject_id
 }
 
 $total_sql = "SELECT COUNT(*) as count FROM materials m

--- a/src/app/admin/borrow-info/borrow-info.component.html
+++ b/src/app/admin/borrow-info/borrow-info.component.html
@@ -25,7 +25,7 @@
             name="heading"
             type="text"
             class="floating-input w-full mt-1 rounded-full border border-gray-300 px-3 pl-6 py-2 focus:ring-opacity-50 text-lg"
-            [(ngModel)]="material.subj"
+            [(ngModel)]="material.subject_name"
           />
           <label for="heading" class="floating-label">Subject Heading</label>
         </div>

--- a/src/app/admin/borrow-info/borrow-info.component.ts
+++ b/src/app/admin/borrow-info/borrow-info.component.ts
@@ -45,7 +45,7 @@ export class BorrowInfoComponent implements OnInit {
   populateForm(): void {
     console.log('CAT ID:', this.material.categoryid);
     this.material.title = this.material.title || 'unknown/empty';
-    this.material.subj = this.material.subj || 'unknown/empty';
+    this.material.subj = this.material.subject_name || 'unknown/empty';
     this.material.accnum = this.material.accnum || 'unknown/empty';
     this.material.author = this.material.author || 'unknown/empty';
     this.material.callno = this.material.callno || 'unknown/empty';

--- a/src/app/admin/borrow/borrow.component.html
+++ b/src/app/admin/borrow/borrow.component.html
@@ -197,7 +197,7 @@
               {{ material.author | slice: 0: 50 }}
               {{ material.author.length > 50 ? '...' : '' }}
             </td>
-            <td>{{ material.subj }}</td>
+            <td>{{ material.subject_name }}</td>
             <td>{{ material.copyright }}</td>
             <td>
               {{ material.callno | slice: 0: 11 }}

--- a/src/app/admin/materials-add/materials-add.component.ts
+++ b/src/app/admin/materials-add/materials-add.component.ts
@@ -15,7 +15,7 @@ export class MaterialsAddComponent {
 
   bookDetails = {
     title: '',
-    heading: '',
+    heading: 0,
     accnum: '',  // This will be updated with the last number for accession number
     category: '',
     author: '',
@@ -47,6 +47,7 @@ export class MaterialsAddComponent {
   subjects: { id: number, subject_name: string }[] = [];  // Holds subject ids and headings
   filteredSubjects: { id: number, subject_name: string }[] = [];
   subjectSearchTerm: string = ''; // To hold the search term
+  subject_id: number ;
 
 
   ngOnInit(): void {
@@ -160,7 +161,9 @@ export class MaterialsAddComponent {
   }
 
   selectSubjectHeading(id: number, subject_name: string): void {
-    this.bookDetails.heading = subject_name;  // Set the subject heading in bookDetails
+    this.subject_id = id;
+    console.log(`Name: ${subject_name} ID: ${this.subject_id}`)
+    this.bookDetails.heading = id;  // Set the subject heading in bookDetails
     this.selectedSubject = { id, subject_name };  // Display selected heading in dropdown
     this.isSubjectDropdownOpen = false;
   }

--- a/src/app/admin/materials/materials.component.html
+++ b/src/app/admin/materials/materials.component.html
@@ -196,7 +196,7 @@
                   {{ material.author | slice: 0:50 }}
                   {{ material.author.length > 50 ? '...' : '' }}
                 </td>
-                <td>{{ material.subj }}</td>
+                <td>{{ material.subject_name }}</td>
                 <td>{{ material.copyright }}</td>
                 <td>
                   {{ material.callno | slice: 0:8 }}

--- a/src/app/client/material-info/material-info.component.html
+++ b/src/app/client/material-info/material-info.component.html
@@ -25,7 +25,7 @@
                 name="heading"
                 type="text"
                 class="floating-input w-full mt-1 rounded-full border border-gray-300 px-3 pl-6 py-2 focus:ring-opacity-50 text-lg"
-                [(ngModel)]="material.subj"
+                [(ngModel)]="material.subject_name"
               />
               <label for="heading" class="floating-label">Subject Heading</label>
             </div>

--- a/src/app/client/material-info/material-info.component.ts
+++ b/src/app/client/material-info/material-info.component.ts
@@ -41,7 +41,7 @@ export class MaterialInfoComponent {
 
     // Populate form fields with material data
     this.material.title = this.material.title || 'unknown/empty';
-    this.material.subj = this.material.subj || 'unknown/empty';
+    this.material.subj = this.material.subject_name || 'unknown/empty';
     this.material.accnum = this.material.accnum || 'unknown/empty';
     this.material.author = this.material.author || 'unknown/empty';
     this.material.callno = this.material.callno || 'unknown/empty';

--- a/src/app/client/search-book/search-book.component.html
+++ b/src/app/client/search-book/search-book.component.html
@@ -327,7 +327,7 @@
                                         {{ material.author.length > 30 ? '...' : '' }}
                                     </td>
                                     <td>
-                                        {{ material.subj }}
+                                        {{ material.subject_name }}
                                     </td>
                                     <td>
                                         {{ material.copyright }}


### PR DESCRIPTION
> Note: use the updated database with materials table updated with subject_id

`controller_lis/add_material.php`

 - will now pass the value of subject_id instead of the subject name to the materials table for better maintainability


`borrow component`
`search a book component`
`materials componenet`

- Updated logic for fetching subjects, get subject_id and map it to the id column under subjects table to get its corresponding subject_name, then include the subject_name to the response to be displayed in the material tables

`borrow-info component`
`material-info component`

- similar logic to the fetching data for tables, subject_id is mapped to get the subject_name from the subjects and include it in the response to be displayed in the input fields.