### PR TITLE
implement pie chart display for analytics page using number of course time in

### DIFF
--- a/controller_lis/count_courses.php
+++ b/controller_lis/count_courses.php
@@ -14,17 +14,23 @@ if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-// Query to get the course counts dynamically
+// Get year and month from the request, default to current year/month if not provided
+$year = isset($_GET['year']) ? (int)$_GET['year'] : date('Y');
+$month = isset($_GET['month']) ? (int)$_GET['month'] : date('m');
+
+// Query to get the course counts based on the provided year and month
 $query = "
     SELECT courses.course_abbreviation, COUNT(*) as student_count
     FROM time_log
     INNER JOIN students ON time_log.user_id = students.id
     INNER JOIN courses ON students.course_id = courses.id
+    WHERE YEAR(time_log.time_in) = ? AND MONTH(time_log.time_in) = ?
     GROUP BY courses.course_abbreviation
 ";
 
-// Execute the query
+// Prepare and execute the query with year and month as parameters
 $stmt = $conn->prepare($query);
+$stmt->bind_param('ii', $year, $month);
 $stmt->execute();
 $result = $stmt->get_result();
 

--- a/controller_lis/count_courses.php
+++ b/controller_lis/count_courses.php
@@ -1,0 +1,46 @@
+<?php
+include 'db_connection.php';
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// Query to get the course counts dynamically
+$query = "
+    SELECT courses.course_abbreviation, COUNT(*) as student_count
+    FROM time_log
+    INNER JOIN students ON time_log.user_id = students.id
+    INNER JOIN courses ON students.course_id = courses.id
+    GROUP BY courses.course_abbreviation
+";
+
+// Execute the query
+$stmt = $conn->prepare($query);
+$stmt->execute();
+$result = $stmt->get_result();
+
+// Prepare the response
+$course_counts = [];
+while ($row = $result->fetch_assoc()) {
+    $course_counts[] = [
+        'course_abbreviation' => $row['course_abbreviation'],
+        'student_count' => $row['student_count']
+    ];
+}
+
+// Output the result as JSON
+echo json_encode($course_counts);
+
+// Close the connection
+$stmt->close();
+$conn->close();
+?>

--- a/src/app/admin/analytics/analytics.component.html
+++ b/src/app/admin/analytics/analytics.component.html
@@ -121,6 +121,7 @@
 <div class="grid grid-cols-2 gap-1 bg-primary pb-[13px]">
     <app-monthly-category-donut></app-monthly-category-donut>
     <app-monthly-users></app-monthly-users>
+    <app-courses-timed-in/>
 </div>
 <!-- <div class="grid grid-cols-1 gap-1 bg-primary pb-[13px]">
     <app-top-ten-user-timein class="mt-4"/>

--- a/src/app/admin/analytics/courses-timed-in/courses-timed-in.component.css
+++ b/src/app/admin/analytics/courses-timed-in/courses-timed-in.component.css
@@ -1,0 +1,37 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.chart-container {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  position: relative;
+  height: 400px; /* Set a fixed height for the container */
+}
+
+/* Dropdown inside chart container */
+.dropdown-container {
+  position: absolute;
+  top: 10px; /* Adjust distance from the top */
+  right: 10px; /* Adjust distance from the right */
+  z-index: 10; /* Ensure dropdown is above other elements */
+}
+
+.dropdown {
+  background-color: #f8f8f8;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  padding: 5px;
+  font-size: 0.875rem; /* Smaller font size */
+  width: 120px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.chart-container canvas {
+  width: 100% !important;
+  height: 100% !important; /* Ensure canvas takes full height of the container */
+}

--- a/src/app/admin/analytics/courses-timed-in/courses-timed-in.component.html
+++ b/src/app/admin/analytics/courses-timed-in/courses-timed-in.component.html
@@ -11,7 +11,7 @@
           <option *ngFor="let month of months" [value]="month.value">{{ month.name }}</option>
         </select>
       </div>
-      <canvas #barChart></canvas>
+      <canvas #pieChart></canvas>
     </div>
   </div>
 </div>

--- a/src/app/admin/analytics/courses-timed-in/courses-timed-in.component.spec.ts
+++ b/src/app/admin/analytics/courses-timed-in/courses-timed-in.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CoursesTimedInComponent } from './courses-timed-in.component';
+
+describe('CoursesTimedInComponent', () => {
+  let component: CoursesTimedInComponent;
+  let fixture: ComponentFixture<CoursesTimedInComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CoursesTimedInComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CoursesTimedInComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/analytics/courses-timed-in/courses-timed-in.component.ts
+++ b/src/app/admin/analytics/courses-timed-in/courses-timed-in.component.ts
@@ -1,0 +1,135 @@
+import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+import { ChartsService } from '../../../../services/charts.service';
+
+Chart.register(...registerables);
+
+@Component({
+  selector: 'app-courses-timed-in',
+  templateUrl: './courses-timed-in.component.html',
+  styleUrls: ['./courses-timed-in.component.css']
+})
+export class CoursesTimedInComponent implements OnInit, AfterViewInit {
+  @ViewChild('pieChart', { static: false }) private chartRef!: ElementRef;
+  public chart: any;
+  public year: number = new Date().getFullYear();
+  public month: number = new Date().getMonth() + 1;
+  public years: number[] = [];
+  public months: { name: string, value: number }[] = [
+    { name: 'January', value: 1 },
+    { name: 'February', value: 2 },
+    { name: 'March', value: 3 },
+    { name: 'April', value: 4 },
+    { name: 'May', value: 5 },
+    { name: 'June', value: 6 },
+    { name: 'July', value: 7 },
+    { name: 'August', value: 8 },
+    { name: 'September', value: 9 },
+    { name: 'October', value: 10 },
+    { name: 'November', value: 11 },
+    { name: 'December', value: 12 }
+  ];
+
+  constructor(private chartsService: ChartsService) {}
+
+  ngOnInit() {
+    this.initializeYears();
+  }
+
+  ngAfterViewInit() {
+    this.fetchData(this.year, this.month);
+  }
+
+  initializeYears() {
+    const currentYear = new Date().getFullYear();
+    this.years = Array.from({ length: 100 }, (_, i) => currentYear - i);
+  }
+
+  fetchData(year: number, month: number) {
+    this.chartsService.getCourseCounts(year, month)
+      .subscribe(data => {
+        console.log('Data received for chart:', data);
+        this.createChart(data);
+      }, error => {
+        console.error('Error fetching data:', error);
+      });
+  }
+
+  createChart(data: any) {
+    const ctx = this.chartRef.nativeElement.getContext('2d');
+    if (!ctx) {
+      console.error('Failed to get canvas context');
+      return;
+    }
+  
+    if (this.chart) {
+      this.chart.destroy();
+    }
+  
+    // Extracting labels and values from the data
+    const labels = data.map((item: any) => item.course_abbreviation);
+    const values = data.map((item: any) => item.student_count);
+  
+    // Array of 11 unique colors with good contrast
+    const backgroundColors = [
+      '#FF6F61', // Coral
+      '#6B5B93', // Purple
+      '#88B04B', // Olive Green
+      '#F7CAC9', // Light Pink
+      '#92A8D1', // Light Blue
+      '#955251', // Burgundy
+      '#B9D3C1', // Mint Green
+      '#F15A29', // Bright Orange
+      '#A35E8D', // Lavender
+      '#7A9E9F', // Teal
+      '#F2C94C'  // Gold
+    ];
+
+  
+    this.chart = new Chart(ctx, {
+      type: 'pie', // Changed from 'doughnut' to 'pie'
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Student Count by Course',
+          data: values,
+          backgroundColor: backgroundColors.slice(0, labels.length), // Ensure colors match the number of labels
+          hoverOffset: 4
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          title: {
+            display: true,
+            text: `Monthly Student Count by Course for ${this.months[this.month - 1].name}, ${this.year}`,
+            font: {
+              size: 18
+            },
+            position: 'bottom',
+            padding: {
+              top: 20,
+              bottom: 10
+            }
+          },
+          legend: {
+            display: true,
+            position: 'bottom'
+          }
+        }
+      }
+    });
+  }
+  
+  
+  onYearChange(event: any) {
+    const selectedYear = +event.target.value;
+    this.fetchData(selectedYear, this.month);
+  }
+
+  onMonthChange(event: any) {
+    const selectedMonth = +event.target.value;
+    this.fetchData(this.year, selectedMonth);
+  }
+}

--- a/src/app/admin/analytics/monthly-category-donut/monthly-category-donut.component.html
+++ b/src/app/admin/analytics/monthly-category-donut/monthly-category-donut.component.html
@@ -3,11 +3,12 @@
     <div class="chart-container">
       <div class="dropdown-container">
         <label for="year" class="sr-only">Select Year:</label>
-        <select id="year" (change)="onYearChange($event)" class="dropdown" [value]="year">
+        <select id="year" [(ngModel)]="year" (change)="onYearChange($event)" class="dropdown">
           <option *ngFor="let year of years" [value]="year">{{ year }}</option>
         </select>
+
         <label for="month" class="sr-only">Select Month:</label>
-        <select id="month" (change)="onMonthChange($event)" class="dropdown" [value]="month">
+        <select id="month" [(ngModel)]="month" (change)="onMonthChange($event)" class="dropdown">
           <option *ngFor="let month of months" [value]="month.value">{{ month.name }}</option>
         </select>
       </div>

--- a/src/app/admin/analytics/monthly-users/monthly-users.component.html
+++ b/src/app/admin/analytics/monthly-users/monthly-users.component.html
@@ -3,7 +3,7 @@
     <div class="chart-container">
       <div class="dropdown-container">
         <label for="year" class="sr-only">Select Year:</label>
-        <select id="year" (change)="onYearChange($event)" class="dropdown">
+        <select id="year" [(ngModel)]="year" (change)="onYearChange($event)" class="dropdown">
           <option *ngFor="let year of years" [value]="year">{{ year }}</option>
         </select>
       </div>

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -75,6 +75,7 @@ import { NavbarAdminComponent } from './admin/navbar-admin/navbar-admin.componen
 import { NavbarSuperAdminComponent } from './super-admin/navbar-super-admin/navbar-super-admin.component';
 import { RequestComponent } from './admin/request/request.component';
 import { FeedbackComponent } from './client/feedback/feedback.component';
+import { CoursesTimedInComponent } from './admin/analytics/courses-timed-in/courses-timed-in.component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/time-in', pathMatch: 'full' },
@@ -154,6 +155,7 @@ const routes: Routes = [
   { path: 'navbar-superadmin', component: NavbarSuperAdminComponent },
   { path: 'request', component: RequestComponent },
   { path: 'feedback', component: FeedbackComponent },
+  { path: 'courses-pie-chart', component: CoursesTimedInComponent},
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -124,6 +124,7 @@ import { ClientSnackbarComponent } from './client/client-snackbar/client-snackba
 import { RequestComponent } from './admin/request/request.component';
 import { EmailService } from '../services/email.service';
 import { FeedbackComponent } from './client/feedback/feedback.component';
+import { CoursesTimedInComponent } from './admin/analytics/courses-timed-in/courses-timed-in.component';
 
 
 @NgModule({
@@ -215,6 +216,7 @@ import { FeedbackComponent } from './client/feedback/feedback.component';
     ClientSnackbarComponent,
     RequestComponent,
     FeedbackComponent,
+    CoursesTimedInComponent,
 
   ],
   imports: [

--- a/src/services/charts.service.ts
+++ b/src/services/charts.service.ts
@@ -47,4 +47,14 @@ export class ChartsService {
       })
     );
   }
+
+  // Inside ChartsService
+  getCourseCounts(year: number, month: number): Observable<any> {
+    return this.http.get<any>(`${environment.apiUrl}/count_courses.php?year=${year}&month=${month}`).pipe(
+      catchError(error => {
+        console.error('Error fetching monthly course data:', error);
+        return throwError(() => new Error('Error fetching monthly course data'));
+      })
+    );
+  }
 }


### PR DESCRIPTION
### PIE CHART
`controller_lis/count_courses.php`

 -  Backend Logic for fetching course time in
    - Takes year and month as parameters then fetches rows in time_log based on that year and month using the time_in as basis
    -  Takes user_id that fits those requirements and matches it with the id column under the students table and gets its corresponding course
    - Counts the total number of time ins for each course for that specific month and year.

`courses-timed-in.component`
- Uses chart.js library
 - Front-end logic to display a pie chart for the visual representation of the number of courses that timed in for the selected month and year
 - Added drop downs for month and year to toggle the displayed data

![image](https://github.com/user-attachments/assets/90c3022c-3ee0-4f06-81ec-165aa5bde748)

___
### BUG FIXES

 - Fixed bug where year and month we not properly shown for the dropdown for the analytics page charts