### PR TITLE
Implement employee repprt generation

### DIFF
--- a/src/app/admin/reports/reports.component.html
+++ b/src/app/admin/reports/reports.component.html
@@ -11,6 +11,7 @@
             <li><a (click)="InventoryPlaceholder('Borrowers')">Borrowers</a></li>
             <li><a (click)="InventoryPlaceholder('Students')">Students</a></li>
             <li><a (click)="InventoryPlaceholder('Faculty')">Faculty</a></li>
+            <li><a (click)="InventoryPlaceholder('Employee')">Employee</a></li>
             <li><a (click)="InventoryPlaceholder('Visitors')">Visitors</a></li>
           </ul>
         </div>

--- a/src/app/admin/reports/reports.component.ts
+++ b/src/app/admin/reports/reports.component.ts
@@ -4,9 +4,11 @@ import { PdfReportInventoryService } from '../../../services/pdf-report-inventor
 import { PdfReportStudentsService } from '../../../services/pdf-report-students.service';
 import { PdfReportVisitorsService } from '../../../services/pdf-report-visitors.service';
 import { PdfReportBorrowersService } from '../../../services/pdf-report-borrowers.service';
+import { PdfReportEmployeesService } from '../../../services/pdf-report-employees.service';
 import { ExcelReportInventoryService } from '../../../services/excel-report-inventory.service';
 import { ExcelReportFacultyService } from '../../../services/excel-report-faculty.service';
 import { ExcelReportStudentsService } from '../../../services/excel-report-students.service';
+import { ExcelReportEmployeesService } from '../../../services/excel-report-employees.service';
 import { ExcelReportVisitorsService } from '../../../services/excel-report-visitors.service';
 import { ExcelReportBorrowersService } from '../../../services/excel-report-borrowers.service';
 import { MaterialsService } from '../../../services/materials.service';
@@ -45,10 +47,12 @@ export class ReportsComponent implements OnInit {
     private materialService: MaterialsService,
     private pdfReportVisitorsService: PdfReportVisitorsService,
     private pdfReportBorrowersService: PdfReportBorrowersService,
+    private pdfReportEmployeesService: PdfReportEmployeesService,
     private excelReportFacultyService: ExcelReportFacultyService,
     private excelReportBorrowersService: ExcelReportBorrowersService,
     private excelReportStudentsService: ExcelReportStudentsService,
     private excelReportVisitorsService: ExcelReportVisitorsService,
+    private excelReportEmployeesService: ExcelReportEmployeesService,
     private reportsService: ReportsService,
   ) {}
 
@@ -184,7 +188,10 @@ export class ReportsComponent implements OnInit {
             break;
       case 'Faculty':
             this.generatePdfFacultyReport();
-            break;      
+            break;  
+      case 'Employee':
+            this.generatePdfEmployeeReport();
+            break;    
       case 'Visitors':
             this.generatePdfVisitorsReport()
             break;              
@@ -220,6 +227,19 @@ export class ReportsComponent implements OnInit {
     console.log('Formatted dateTo:', this.formatDate(this.dateTo));
   
     this.pdfReportFacultyService.generatePDF(
+      'pdf-preview',
+      this.formatDate(this.dateFrom),
+      this.formatDate(this.dateTo),
+      (loading) => this.isLoading = loading,
+      (show) => this.showInitialDisplay = show
+    );
+  }
+
+  generatePdfEmployeeReport() {
+    console.log('Formatted dateFrom:', this.formatDate(this.dateFrom));
+    console.log('Formatted dateTo:', this.formatDate(this.dateTo));
+  
+    this.pdfReportEmployeesService.generatePDF(
       'pdf-preview',
       this.formatDate(this.dateFrom),
       this.formatDate(this.dateTo),
@@ -274,6 +294,8 @@ export class ReportsComponent implements OnInit {
             break;
       case 'Faculty':
             this.generateExcelFacultyReport();
+      case 'Employee':
+            this.generateExcelEmployeeReport();
             break;      
       case 'Visitors':
             this.generateExcelVisitorsReport();
@@ -309,6 +331,14 @@ export class ReportsComponent implements OnInit {
 
   generateExcelFacultyReport() {
     this.excelReportFacultyService.generateExcelReport(
+        this.formatDate(this.dateFrom),
+        this.formatDate(this.dateTo),
+        (loading) => this.isLoading = loading
+    );
+  }
+
+  generateExcelEmployeeReport() {
+    this.excelReportEmployeesService.generateExcelReport(
         this.formatDate(this.dateFrom),
         this.formatDate(this.dateTo),
         (loading) => this.isLoading = loading

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -92,10 +92,12 @@ import { PdfReportInventoryService } from '../services/pdf-report-inventory.serv
 import { PdfReportFacultyService } from '../services/pdf-report-faculty.service';
 import { PdfReportStudentsService } from '../services/pdf-report-students.service';
 import { PdfReportVisitorsService } from '../services/pdf-report-visitors.service';
+import { PdfReportEmployeesService } from '../services/pdf-report-employees.service';
 import { ExcelReportInventoryService } from '../services/excel-report-inventory.service';
 import { ExcelReportFacultyService } from '../services/excel-report-faculty.service';
 import { ExcelReportStudentsService } from '../services/excel-report-students.service';
 import { ExcelReportVisitorsService } from '../services/excel-report-visitors.service';
+import { ExcelReportEmployeesService } from '../services/excel-report-employees.service';
 import { CurrentDateYearService } from '../services/current-date-year.service';
 import { PdfReportBorrowersService } from '../services/pdf-report-borrowers.service';
 import { CoursesComponent } from './super-admin/courses/courses.component';
@@ -268,6 +270,8 @@ import { CoursesTimedInComponent } from './admin/analytics/courses-timed-in/cour
     AnalyticsService,
     EmailService,
     AuthGuardService,
+    PdfReportEmployeesService,
+    ExcelReportEmployeesService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/services/excel-report-employees.service.spec.ts
+++ b/src/services/excel-report-employees.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ExcelReportEmployeesService } from './excel-report-employees.service';
+
+describe('ExcelReportEmployeesService', () => {
+  let service: ExcelReportEmployeesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ExcelReportEmployeesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/services/excel-report-employees.service.ts
+++ b/src/services/excel-report-employees.service.ts
@@ -1,0 +1,137 @@
+import { Injectable } from '@angular/core';
+import { RecordsService } from './records.service';
+import * as ExcelJS from 'exceljs';
+import { saveAs } from 'file-saver';
+import { CurrentDateYearService } from './current-date-year.service';
+
+@Injectable()
+export class ExcelReportEmployeesService {
+
+  constructor(
+    private recordsService: RecordsService, 
+    private currentDateYearService: CurrentDateYearService
+  ) {}
+
+  async generateExcelReport(dateFrom: string | null, dateTo: string | null, setLoading: (loading: boolean) => void) {
+    setLoading(true);
+
+    try {
+      const allFacultyData = await this.fetchAllFacultyLogs(dateFrom, dateTo);
+
+      const workbook = new ExcelJS.Workbook();
+      const worksheet = workbook.addWorksheet('Faculty Time Logs');
+
+      // Titles
+      const title = "Polytechnic University of the Philippines - Taguig Campus";
+      const subtitle = "PUPT FACULTY TIME LOGS";
+      const dateAndTime = `YEAR AS OF ${this.currentDateYearService.getCurrentYearAndDate('no_date')}`;
+
+      // Add title and merge cells
+      worksheet.mergeCells('A1:E1');
+      worksheet.getCell('A1').value = title;
+      worksheet.getCell('A1').font = { bold: true, size: 16, color: { argb: 'FF800000' } };
+      worksheet.getCell('A1').alignment = { horizontal: 'center' };
+
+      // Add subtitle and date
+      worksheet.mergeCells('A2:E2');
+      worksheet.getCell('A2').value = subtitle;
+      worksheet.getCell('A2').font = { bold: true, size: 12, color: { argb: 'FF000000' } };
+      worksheet.getCell('A2').alignment = { horizontal: 'center' };
+
+      worksheet.mergeCells('A3:E3');
+      worksheet.getCell('A3').value = dateAndTime;
+      worksheet.getCell('A3').font = { bold: false, size: 12, color: { argb: 'FF252525' } };
+      worksheet.getCell('A3').alignment = { horizontal: 'center' };
+
+      worksheet.addRow([]);
+
+      // Add header row
+      worksheet.addRow(['Faculty Code', 'Name', 'Time In', 'Time Out']);
+
+      // Populate data rows
+      allFacultyData.forEach((faculty: any) => {
+        worksheet.addRow([
+          faculty.employee_number,
+          faculty.name,
+          faculty.time_in,
+          faculty.time_out ? faculty.time_out : 'await'
+        ]);
+      });
+
+      // Column widths
+      worksheet.columns = [
+        { width: 25 },
+        { width: 40 },
+        { width: 35 },
+        { width: 35 }
+      ];
+
+      // Style headers
+      worksheet.getRow(5).eachCell(cell => {
+        cell.font = { bold: true, color: { argb: 'FFFFFFFF' } };
+        cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF800000' } };
+        cell.alignment = { horizontal: 'center', vertical: 'middle' };
+        cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+      });
+
+      // Style data rows
+      worksheet.eachRow((row, rowNumber) => {
+        if (rowNumber > 5) { // Skip title and header rows
+          row.eachCell(cell => {
+            cell.alignment = { vertical: 'middle', horizontal: 'left' };
+            cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+          });
+        }
+      });
+
+      worksheet.addRow([]);
+
+      // Footer information
+      const footerStartRow = worksheet.lastRow.number + 1;
+      worksheet.addRow([`Total Faculty Records: ${allFacultyData.length}`]);
+      worksheet.addRow([`Report Generated On: ${this.currentDateYearService.getCurrentYearAndDate('get_date')}`]);
+
+      if (dateFrom && dateTo) {
+        worksheet.addRow([`Time Log Ranging From: ${this.currentDateYearService.formatDateString(dateFrom)} - ${this.currentDateYearService.formatDateString(dateTo)}`]);
+      }
+
+      // Footer style
+      for (let i = footerStartRow; i <= worksheet.lastRow.number; i++) {
+        worksheet.getRow(i).eachCell(cell => {
+          cell.font = { bold: true, color: { argb: 'FF800000' } };
+          cell.alignment = { horizontal: 'left' };
+        });
+      }
+
+      // Generate Excel file
+      const buffer = await workbook.xlsx.writeBuffer();
+      const blob = new Blob([buffer], { type: 'application/octet-stream' });
+      saveAs(blob, `Faculty_Time_Logs_${this.currentDateYearService.getCurrentYearAndDate('get_date')}.xlsx`);
+
+    } catch (error) {
+      console.error('Error generating Excel:', error);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  private async fetchAllFacultyLogs(dateFrom: string | null, dateTo: string | null): Promise<any[]> {
+    let allRecords: any[] = [];
+    let page = 1;
+    const pageSize = 10;
+    let hasMoreRecords = true;
+
+    while (hasMoreRecords) {
+      const response = await this.recordsService.getLogsReports('pupt-employee', pageSize, page, dateFrom, dateTo).toPromise();
+      const records = response?.records || [];
+      allRecords = allRecords.concat(records);
+
+      if (records.length < pageSize) {
+        hasMoreRecords = false;
+      } else {
+        page++;
+      }
+    }
+    return allRecords;
+  }
+}

--- a/src/services/excel-report-employees.service.ts
+++ b/src/services/excel-report-employees.service.ts
@@ -49,12 +49,12 @@ export class ExcelReportEmployeesService {
       worksheet.addRow(['Faculty Code', 'Name', 'Time In', 'Time Out']);
 
       // Populate data rows
-      allFacultyData.forEach((faculty: any) => {
+      allFacultyData.forEach((employee: any) => {
         worksheet.addRow([
-          faculty.employee_number,
-          faculty.name,
-          faculty.time_in,
-          faculty.time_out ? faculty.time_out : 'await'
+          employee.employee_number,
+          employee.name,
+          employee.time_in,
+          employee.time_out ? employee.time_out : 'await'
         ]);
       });
 

--- a/src/services/pdf-report-employees.service.spec.ts
+++ b/src/services/pdf-report-employees.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PdfReportEmployeesService } from './pdf-report-employees.service';
+
+describe('PdfReportEmployeesService', () => {
+  let service: PdfReportEmployeesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PdfReportEmployeesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/services/pdf-report-employees.service.ts
+++ b/src/services/pdf-report-employees.service.ts
@@ -1,0 +1,134 @@
+import { Injectable } from '@angular/core';
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { RecordsService } from './records.service';
+import { CurrentDateYearService } from './current-date-year.service';
+
+@Injectable()
+export class PdfReportEmployeesService {
+  constructor(private recordsService: RecordsService, 
+              private currentDateYearService: CurrentDateYearService) {}
+
+  generatePDF(
+    iframeId: string, 
+    dateFrom: string | null, 
+    dateTo: string | null,
+    setLoading: (loading: boolean) => void, 
+    setShowInitialDisplay: (show: boolean) => void
+  ) {
+    setLoading(true);
+    setShowInitialDisplay(false);
+
+    const doc = new jsPDF('landscape');
+    const title = "Polytechnic University of the Philippines - Taguig Campus";
+    const subtitle = "PUPT FACULTY TIME LOGS";
+    const dateAndTime = `YEAR AS OF ${this.currentDateYearService.getCurrentYearAndDate('no_date')}`;
+
+    // Logo settings
+    const imgBase64 = '../assets/pup.png';
+    const imgXPosition = 15; // X position for the image
+    const imgYPosition = 5; // Y position for the image
+    const imgWidth = 23; // Image width
+    const imgHeight = 23; // Image height
+
+    // Add the image to the PDF at the top left corner
+    doc.addImage(imgBase64, 'PNG', imgXPosition, imgYPosition, imgWidth, imgHeight);
+
+    // Adjust text positioning to start below the image
+    const textStartY = 12; // Position the text below the image with a margin
+
+    doc.setFontSize(18);
+    doc.setTextColor("#800000");
+    doc.text(title, doc.internal.pageSize.getWidth() / 2, textStartY, { align: "center" });
+
+    doc.setFontSize(12);
+    doc.setTextColor("#000000");
+    doc.text(subtitle, doc.internal.pageSize.getWidth() / 2, textStartY + 8, { align: "center" });
+
+    doc.setFontSize(12);
+    doc.setTextColor("#252525");
+    doc.text(dateAndTime, doc.internal.pageSize.getWidth() / 2, textStartY + 15, { align: "center" });
+
+    let startY = textStartY + 23; // Adjust the table start Y position accordingly
+
+    const allFacultyData: any[] = [];
+    let currentPage = 1;
+    const pageSize = 10;
+
+    const fetchAllPages = () => {
+      this.recordsService.getLogsReports('pupt-employee', pageSize, currentPage, dateFrom, dateTo).subscribe(
+        response => {
+          const facultyData = response?.records || [];
+          allFacultyData.push(...facultyData);
+
+          if (facultyData.length === pageSize) {
+            // If there are still more records, increment the page number and fetch the next page
+            currentPage++;
+            fetchAllPages();
+          } else {
+            // Once all pages are fetched, generate the PDF
+            const tableData = allFacultyData.map((faculty: any) => [
+              faculty.employee_number,
+              faculty.name,
+              faculty.time_in,
+              faculty.time_out ? faculty.time_out : 'await'
+            ]);
+
+            autoTable(doc, {
+              head: [['Employee Number', 'Name','Time In', 'Time Out']],
+              body: tableData,
+              startY: startY,
+              theme: 'grid',
+              headStyles: { fillColor: '#800000', textColor: [255, 255, 255] },
+              columnStyles: {
+                0: { cellWidth: 40 },
+                1: { cellWidth: 70 },
+                3: { cellWidth: 60 },
+                4: { cellWidth: 60 }
+              },
+              styles: {
+                overflow: 'linebreak',
+                cellPadding: 2
+              },
+              didDrawPage: (data) => {
+                startY = data.cursor.y;
+              }
+            });
+
+            const labelXPosition = 20;
+            const valueXPosition = 80;
+
+            doc.setFontSize(10);
+            // Date generated
+            doc.text(`Report Generated On:`, labelXPosition, doc.internal.pageSize.getHeight() - 20);
+            doc.text(`${this.currentDateYearService.getCurrentYearAndDate('get_date')}`, valueXPosition, doc.internal.pageSize.getHeight() - 20);
+
+            // Total records
+            doc.text(`Total Faculty Records:`, labelXPosition, doc.internal.pageSize.getHeight() - 15);
+            doc.text(`${allFacultyData.length}`, valueXPosition, doc.internal.pageSize.getHeight() - 15);
+
+            // Filter
+            if (dateFrom && dateTo) {
+              doc.text(`Time Log Ranging From:`, labelXPosition, doc.internal.pageSize.getHeight() - 10);
+              doc.text(`${this.currentDateYearService.formatDateString(dateFrom)} - ${this.currentDateYearService.formatDateString(dateTo)}`, valueXPosition, doc.internal.pageSize.getHeight() - 10);
+            }
+
+            const pdfBlob = doc.output('blob');
+            const pdfUrl = URL.createObjectURL(pdfBlob);
+            const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
+            iframe.src = pdfUrl;
+
+            setLoading(false);
+          }
+        },
+        error => {
+          console.error('Error generating PDF:', error);
+          setLoading(false);
+        }
+      );
+    };
+
+    // Start fetching the records
+    fetchAllPages();
+  }
+}

--- a/src/services/pdf-report-employees.service.ts
+++ b/src/services/pdf-report-employees.service.ts
@@ -67,11 +67,11 @@ export class PdfReportEmployeesService {
             fetchAllPages();
           } else {
             // Once all pages are fetched, generate the PDF
-            const tableData = allFacultyData.map((faculty: any) => [
-              faculty.employee_number,
-              faculty.name,
-              faculty.time_in,
-              faculty.time_out ? faculty.time_out : 'await'
+            const tableData = allFacultyData.map((employee: any) => [
+              employee.employee_number,
+              employee.name,
+              employee.time_in,
+              employee.time_out ? employee.time_out : 'await'
             ]);
 
             autoTable(doc, {


### PR DESCRIPTION
- Implement employee report generation for PDF adn Excel file formats.
- Uses the same backend as the html tables: `get_records.php`
- Services to handle report generation:

   - PDF: `pdf-report-employees.service.ts`
   - Excel: `excel-report-employees.service.ts`

> PDF Preview:

![image](https://github.com/user-attachments/assets/d3b895b9-51f2-4f0b-b099-cff6b8a78e24)

> Save as Excel:

![image](https://github.com/user-attachments/assets/7967343f-3824-42b3-bf04-8d15b4534f96)
