### PR TITLE
implement pagination state preservation

### DIFF
--- a/src/app/admin/borrow/borrow.component.ts
+++ b/src/app/admin/borrow/borrow.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { BorrowService } from '../../../services/borrow.service';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { PageStateService } from '../../../services/page-state.service';
 
 @Component({
   selector: 'app-borrow',
@@ -24,9 +25,12 @@ export class BorrowComponent implements OnInit {
   sortField: string = 'date_added';
   sortOrder: string = 'DESC';
 
-  constructor(private borrowService: BorrowService) {}
+  constructor(
+    private borrowService: BorrowService,
+    private pageStateService: PageStateService) {}
 
   ngOnInit() {
+    this.currentPage = this.pageStateService.getMaterialCurrentPage('borrow');
     this.loadMaterials();
     this.searchTerms.pipe(
       debounceTime(300),
@@ -130,6 +134,7 @@ export class BorrowComponent implements OnInit {
 
   onPageChange(page: number) {
     this.currentPage = page;
+    this.pageStateService.setMaterialCurrentPage(page, 'borrow');
     this.loadMaterials();
   }
 
@@ -170,6 +175,7 @@ export class BorrowComponent implements OnInit {
     this.searchTerm = '';
     this.category = '';
     this.currentPage = 1;
+    this.pageStateService.setMaterialCurrentPage(this.currentPage, 'borrow');
     this.categoryPlaceholder = 'Choose category';
     this.sortField = 'date_added';
     this.sortOrder = 'DESC';

--- a/src/app/admin/materials-edit/materials-edit.component.ts
+++ b/src/app/admin/materials-edit/materials-edit.component.ts
@@ -20,6 +20,7 @@ export class MaterialsEditComponent implements OnInit {
   subjectSearchTerm = '';
   filteredSubjects: any[] = [];
   subjects: { id: number, subject_name: string }[] = [];
+  currentPage;
 
   constructor(
     private route: ActivatedRoute,
@@ -37,6 +38,7 @@ export class MaterialsEditComponent implements OnInit {
       }));
 
       const accnum = this.route.snapshot.paramMap.get('accnum');
+       this.currentPage = this.route.snapshot.paramMap.get('currentPage');
       if (accnum) {
         this.materialsService.getMaterialDetails(accnum).subscribe(data => {
           this.material = data;

--- a/src/app/admin/materials/materials.component.ts
+++ b/src/app/admin/materials/materials.component.ts
@@ -2,8 +2,9 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { MaterialsService } from '../../../services/materials.service';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { SnackbarComponent } from '../snackbar/snackbar.component';
+import { PageStateService } from '../../../services/page-state.service';
 
 @Component({
   selector: 'app-materials',
@@ -45,10 +46,14 @@ export class MaterialsComponent implements OnInit {
 
   constructor(
     private materialsService: MaterialsService, 
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute,
+    private pageStateService: PageStateService
   ) {}
 
   ngOnInit() {
+    this.currentPage = this.pageStateService.getMaterialCurrentPage('materials');
+    
     this.loadMaterials(); 
     this.loadCategories(); 
 
@@ -285,6 +290,7 @@ export class MaterialsComponent implements OnInit {
 
   onPageChange(page: number) {
     this.currentPage = page;
+    this.pageStateService.setMaterialCurrentPage(page, 'materials');
     this.loadMaterials();
   }
 
@@ -324,6 +330,7 @@ export class MaterialsComponent implements OnInit {
     this.searchTerm = '';
     this.category = '';
     this.currentPage = 1;
+    this.pageStateService.setMaterialCurrentPage(this.currentPage, 'materials');
     this.selectedMaterialIds = [];
     this.categoryPlaceholder = 'Choose category';
     this.sortField = 'date_added';

--- a/src/app/client/search-book/search-book.component.ts
+++ b/src/app/client/search-book/search-book.component.ts
@@ -5,6 +5,7 @@ import { ClientSnackbarComponent } from '../client-snackbar/client-snackbar.comp
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import { Router, ActivatedRoute } from '@angular/router';
+import { PageStateService } from '../../../services/page-state.service';
 
 @Component({
   selector: 'app-search-book',
@@ -56,10 +57,13 @@ export class SearchBookComponent implements OnInit {
     private bookRequestService: BookRequestService,
     private router: Router,
     private route: ActivatedRoute,
-    private renderer: Renderer2
+    private renderer: Renderer2,
+    private pageStateService: PageStateService
   ) {}
 
   ngOnInit() {
+    this.currentPage = this.pageStateService
+        .getMaterialCurrentPage('searchBook');
     this.loadMaterials();
     this.loadCategories();
     this.route.queryParams.subscribe(params => {
@@ -169,6 +173,7 @@ export class SearchBookComponent implements OnInit {
 
   onPageChange(page: number) {
     this.currentPage = page;
+    this.pageStateService.setMaterialCurrentPage(page, 'searchBook');
     this.loadMaterials();
   }
 
@@ -209,6 +214,8 @@ export class SearchBookComponent implements OnInit {
     this.searchTerm = '';
     this.category = '';
     this.currentPage = 1;
+    this.pageStateService
+        .setMaterialCurrentPage(this.currentPage, 'searchBook');
     this.categoryPlaceholder = 'Choose category';
     this.sortField = 'date_added';
     this.sortOrder = 'DESC';

--- a/src/app/super-admin/books/books.component.ts
+++ b/src/app/super-admin/books/books.component.ts
@@ -3,6 +3,7 @@ import { MaterialsService } from '../../../services/materials.service';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import { Router } from '@angular/router';
+import { PageStateService } from '../../../services/page-state.service';
 
 @Component({
   selector: 'app-books',
@@ -42,10 +43,13 @@ export class BooksComponent implements OnInit {
 
   constructor(
     private materialsService: MaterialsService, 
-    private router: Router
+    private router: Router,
+    private pageStateService: PageStateService,
   ) {}
 
   ngOnInit() {
+    this.currentPage = this.pageStateService
+        .getMaterialCurrentPage('materialsSuperAdmin');
     this.loadMaterials(); 
     this.loadCategories(); 
 
@@ -298,6 +302,7 @@ export class BooksComponent implements OnInit {
 
   onPageChange(page: number) {
     this.currentPage = page;
+    this.pageStateService.setMaterialCurrentPage(page, 'materialsSuperAdmin');
     this.loadMaterials();
   }
 
@@ -382,6 +387,8 @@ export class BooksComponent implements OnInit {
     this.searchTerm = '';
     this.category = '';
     this.currentPage = 1;
+    this.pageStateService
+        .setMaterialCurrentPage(this.currentPage, 'materialsSuperAdmin');
     this.selectedMaterialIds = [];
     this.categoryPlaceholder = 'Choose category';
     this.sortField = 'date_added';

--- a/src/app/super-admin/employees/employees.component.ts
+++ b/src/app/super-admin/employees/employees.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { RecordsService } from '../../../services/records.service';
 import { SnackbarComponent } from '../../admin/snackbar/snackbar.component';
 import { Subject, debounceTime } from 'rxjs';
+import { PageStateService } from '../../../services/page-state.service';
 
 @Component({
   selector: 'app-employees',
@@ -23,9 +24,12 @@ export class EmployeesComponent implements OnInit {
   searchTerm: string = '';
   searchSubject: Subject<string> = new Subject<string>();
 
-  constructor(private recordsService: RecordsService) {}
+  constructor(private recordsService: RecordsService,
+              private pageStateService: PageStateService
+  ) {}
 
   ngOnInit(): void {
+    this.currentPage = this.pageStateService.getMaterialCurrentPage('employee');
     this.fetchRecords();
 
     this.searchSubject.pipe(debounceTime(300)).subscribe(term => {
@@ -85,11 +89,14 @@ export class EmployeesComponent implements OnInit {
 
   onPageChange(page: number) {
     this.currentPage = page;
+    this.pageStateService.setMaterialCurrentPage(page, 'employee');
     this.fetchRecords();
   }
 
   clearLogType() {
     this.searchTerm = '';
+    this.currentPage = 1;
+    this.pageStateService.setMaterialCurrentPage(this.currentPage, 'employee');
     this.fetchRecords();
   }
 }

--- a/src/app/super-admin/faculty/faculty.component.ts
+++ b/src/app/super-admin/faculty/faculty.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { RecordsService } from '../../../services/records.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { Subject, debounceTime } from 'rxjs';
+import { PageStateService } from '../../../services/page-state.service';
 
 @Component({
   selector: 'app-faculty',
@@ -27,10 +28,12 @@ export class FacultyComponent implements OnInit {
   constructor(
     private recordsService: RecordsService,
     private router: Router,
-    private snackbarService: SnackbarService
+    private snackbarService: SnackbarService,
+    private pageStateService: PageStateService
   ) {}
 
   ngOnInit(): void {
+    this.currentPage = this.pageStateService.getMaterialCurrentPage('faculty');
     this.fetchRecords();
 
     this.searchSubject.pipe(debounceTime(300)).subscribe(term => {
@@ -90,11 +93,14 @@ export class FacultyComponent implements OnInit {
 
   onPageChange(page: number) {
     this.currentPage = page;
+    this.pageStateService.setMaterialCurrentPage(page, 'faculty');
     this.fetchRecords();
   }
   
   clearLogType() {
     this.searchTerm = '';
+    this.currentPage = 1;
+    this.pageStateService.setMaterialCurrentPage(this.currentPage, 'faculty');
     this.fetchRecords();
   }
 }

--- a/src/app/super-admin/student/student.component.ts
+++ b/src/app/super-admin/student/student.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { RecordsService } from '../../../services/records.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { Subject, debounceTime } from 'rxjs';
+import { PageStateService } from '../../../services/page-state.service';
 
 @Component({
   selector: 'app-student',
@@ -23,9 +24,11 @@ export class StudentComponent implements OnInit {
   searchSubject: Subject<string> = new Subject<string>();
 
   constructor(private recordsService: RecordsService, 
-              private snackbarService: SnackbarService) {}
+              private snackbarService: SnackbarService,
+              private pageStateService: PageStateService,) {}
 
   ngOnInit(): void {
+    this.currentPage = this.pageStateService.getMaterialCurrentPage('students');
     this.fetchRecords();
     this.searchSubject.pipe(
       debounceTime(300)
@@ -52,6 +55,7 @@ export class StudentComponent implements OnInit {
 
   onPageChange(page: number) {
     this.currentPage = page;
+    this.pageStateService.setMaterialCurrentPage(page, 'students');
     this.fetchRecords();
   }
 
@@ -88,6 +92,8 @@ export class StudentComponent implements OnInit {
 
   clearLogType() {
     this.searchTerm = '';
+    this.currentPage = 1;
+    this.pageStateService.setMaterialCurrentPage(this.currentPage, 'students');
     this.fetchRecords();
   }
 }

--- a/src/app/super-admin/visitor/visitor.component.ts
+++ b/src/app/super-admin/visitor/visitor.component.ts
@@ -3,6 +3,7 @@ import { RecordsService } from '../../../services/records.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { Router } from '@angular/router';
 import { Subject, debounceTime } from 'rxjs';
+import { PageStateService } from '../../../services/page-state.service';
 
 @Component({
   selector: 'app-visitor',
@@ -25,10 +26,12 @@ export class VisitorComponent implements OnInit {
   constructor(
     private recordsService: RecordsService, 
     private snackbarService: SnackbarService, 
-    private router: Router
+    private router: Router,
+    private pageStateService: PageStateService
   ) {}
 
   ngOnInit(): void {
+    this.currentPage = this.pageStateService.getMaterialCurrentPage('visitor');
     this.fetchRecords();
 
     this.searchSubject.pipe(debounceTime(300)).subscribe(term => {
@@ -51,6 +54,8 @@ export class VisitorComponent implements OnInit {
 
   clearLogType() {
     this.searchTerm = '';
+    this.currentPage = 1;
+    this.pageStateService.setMaterialCurrentPage(this.currentPage, 'visitor');
     this.fetchRecords();
   }
 
@@ -66,6 +71,7 @@ export class VisitorComponent implements OnInit {
 
   onPageChange(page: number) {
     this.currentPage = page;
+    this.pageStateService.setMaterialCurrentPage(page, 'visitor');
     this.fetchRecords();
   }
 

--- a/src/services/page-state.service.spec.ts
+++ b/src/services/page-state.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PageStateService } from './page-state.service';
+
+describe('PageStateService', () => {
+  let service: PageStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PageStateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/services/page-state.service.ts
+++ b/src/services/page-state.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PageStateService {
+  // Behavior subjects for different tables
+  private materialPageSource = new BehaviorSubject<number>(1);
+  private borrowPageSource = new BehaviorSubject<number>(1);
+  private materialSuperAdminPageSource = new BehaviorSubject<number>(1);
+  private studentsPageSource = new BehaviorSubject<number>(1);
+  private facultyPageSource = new BehaviorSubject<number>(1);
+  private visitorPageSource = new BehaviorSubject<number>(1);
+  private employeePageSource = new BehaviorSubject<number>(1);
+
+  // Observables for external components to subscribe to
+  materialPage$ = this.materialPageSource.asObservable();
+  borrowPage$ = this.borrowPageSource.asObservable();
+  materialSuperAdminPage$ = this.materialSuperAdminPageSource.asObservable();
+  studentsPage$ = this.studentsPageSource.asObservable();
+  facultyPage$ = this.facultyPageSource.asObservable();
+  visitorPage$ = this.visitorPageSource.asObservable();
+  employeePage$ = this.employeePageSource.asObservable();
+
+  // Set the current page for a specific table
+  setMaterialCurrentPage(page: number, table: string): void {
+    switch (table) {
+      case 'materials':
+        this.materialPageSource.next(page);
+        break;
+      case 'borrow':
+        this.borrowPageSource.next(page);
+        break;
+      case 'materialsSuperAdmin':
+        this.materialSuperAdminPageSource.next(page);
+        break;
+      case 'students':
+        this.studentsPageSource.next(page);
+        break;
+      case 'faculty':
+        this.facultyPageSource.next(page);
+        break;
+      case 'visitor':
+        this.visitorPageSource.next(page);
+        break;
+      case 'employee':
+        this.employeePageSource.next(page);
+        break;
+      default:
+        console.error(`Unknown table: ${table}`);
+    }
+  }
+
+  // Get the current page value for a specific table
+  getMaterialCurrentPage(table: string): number {
+    switch (table) {
+      case 'materials':
+        return this.materialPageSource.getValue();
+      case 'borrow':
+        return this.borrowPageSource.getValue();
+      case 'materialsSuperAdmin':
+        return this.materialSuperAdminPageSource.getValue();
+      case 'students':
+        return this.studentsPageSource.getValue();
+      case 'faculty':
+        return this.facultyPageSource.getValue();
+      case 'visitor':
+        return this.visitorPageSource.getValue();
+      case 'employee':
+        return this.employeePageSource.getValue();
+      default:
+        return 1; // Default value
+    }
+  }
+}

--- a/src/services/page-state.service.ts
+++ b/src/services/page-state.service.ts
@@ -13,6 +13,7 @@ export class PageStateService {
   private facultyPageSource = new BehaviorSubject<number>(1);
   private visitorPageSource = new BehaviorSubject<number>(1);
   private employeePageSource = new BehaviorSubject<number>(1);
+  private searchBookPageSource = new BehaviorSubject<number>(1);
 
   // Observables for external components to subscribe to
   materialPage$ = this.materialPageSource.asObservable();
@@ -22,6 +23,7 @@ export class PageStateService {
   facultyPage$ = this.facultyPageSource.asObservable();
   visitorPage$ = this.visitorPageSource.asObservable();
   employeePage$ = this.employeePageSource.asObservable();
+  searchBookPage$ = this.searchBookPageSource.asObservable();
 
   // Set the current page for a specific table
   setMaterialCurrentPage(page: number, table: string): void {
@@ -46,6 +48,9 @@ export class PageStateService {
         break;
       case 'employee':
         this.employeePageSource.next(page);
+      case 'searchBook':
+        this.searchBookPageSource.next(page);
+        break;
         break;
       default:
         console.error(`Unknown table: ${table}`);
@@ -69,6 +74,8 @@ export class PageStateService {
         return this.visitorPageSource.getValue();
       case 'employee':
         return this.employeePageSource.getValue();
+      case 'searchBook':
+        return this.searchBookPageSource.getValue();
       default:
         return 1; // Default value
     }


### PR DESCRIPTION
`page-state.service.ts`

- Handles the storing of pages for the different tables that uses pagination preservation 

Pagination preservation was implemented on the following components:

`Client:`

- Search a book

`Librarian:`

- Borrow
- Materials

`Super Admin:`

- Materials
- Students
- Faculty
- Visitor
- Employee


> - These components are now able to handle pagination preservation, when leaving the page, it should still display the last page opened
> - Current can be set back to 1 using the clear button 
>    - Will also set the value of the corresponding observable in the page state service to 1

